### PR TITLE
fix: add rhoas schemas for testing

### DIFF
--- a/schemas/ansible_tower_job_template_launch_sink_0.1.json
+++ b/schemas/ansible_tower_job_template_launch_sink_0.1.json
@@ -1,0 +1,161 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "ansible_tower_basic_auth_password": {
+      "oneOf": [
+        {
+          "description": "Basic Authentication Password",
+          "format": "password",
+          "title": "Basic Authentication Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the ansible_tower_basic_auth_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Basic Authentication Password",
+      "x-group": "credentials"
+    },
+    "ansible_tower_basic_auth_username": {
+      "description": "Authentication Username",
+      "title": "Basic Authentication Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "ansible_tower_host": {
+      "description": "The Ansible Tower Host",
+      "title": "Ansible Tower Host",
+      "type": "string"
+    },
+    "ansible_tower_host_insecure": {
+      "default": false,
+      "description": "Set whether all server certificates should be trusted",
+      "title": "Set whether all server certificates should be trusted",
+      "type": "boolean"
+    },
+    "ansible_tower_host_verify": {
+      "default": true,
+      "description": "Set whether hostname verification is enabled",
+      "title": "Set whether hostname verification is enabled",
+      "type": "boolean"
+    },
+    "ansible_tower_job_template_id": {
+      "description": "The Job Template ID",
+      "title": "The Job Template ID",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "ansible_tower_host",
+    "ansible_tower_basic_auth_username",
+    "ansible_tower_basic_auth_password",
+    "ansible_tower_job_template_id",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_cloudwatch_sink_0.1.json
+++ b/schemas/aws_cloudwatch_sink_0.1.json
@@ -1,0 +1,207 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS.",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_cw_namespace": {
+      "description": "The cloud watch metric namespace.",
+      "title": "Cloud Watch Namespace",
+      "type": "string"
+    },
+    "aws_override_endpoint": {
+      "default": false,
+      "description": "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+      "title": "Endpoint Overwrite",
+      "type": "boolean"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to.",
+      "enum": [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "fips-us-east-1",
+        "fips-us-east-2",
+        "fips-us-west-1",
+        "fips-us-west-2",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "cn-north-1",
+        "cn-northwest-1",
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-iso-east-1",
+        "us-iso-west-1",
+        "us-isob-east-1"
+      ],
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS.",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "aws_uri_endpoint_override": {
+      "description": "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+      "title": "Overwrite Endpoint URI",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_cw_namespace",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_ddb_sink_0.1.json
+++ b/schemas/aws_ddb_sink_0.1.json
@@ -1,0 +1,220 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_operation": {
+      "default": "PutItem",
+      "description": "The operation to perform (one of PutItem, UpdateItem, DeleteItem)",
+      "example": "PutItem",
+      "title": "Operation",
+      "type": "string"
+    },
+    "aws_override_endpoint": {
+      "default": false,
+      "description": "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+      "title": "Endpoint Overwrite",
+      "type": "boolean"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to",
+      "enum": [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "fips-us-east-1",
+        "fips-us-east-2",
+        "fips-us-west-1",
+        "fips-us-west-2",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "cn-north-1",
+        "cn-northwest-1",
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-iso-east-1",
+        "us-iso-west-1",
+        "us-isob-east-1"
+      ],
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "aws_table": {
+      "description": "Name of the DynamoDB table to look at",
+      "title": "Table",
+      "type": "string"
+    },
+    "aws_uri_endpoint_override": {
+      "description": "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+      "title": "Overwrite Endpoint URI",
+      "type": "string"
+    },
+    "aws_write_capacity": {
+      "default": 1,
+      "description": "The provisioned throughput to reserved for writing resources to your table",
+      "title": "Write Capacity",
+      "type": "integer"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_table",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_ddb_streams_source_0.1.json
+++ b/schemas/aws_ddb_streams_source_0.1.json
@@ -1,0 +1,219 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_delay": {
+      "default": 500,
+      "description": "Milliseconds before the next poll from database",
+      "title": "Delay",
+      "type": "integer"
+    },
+    "aws_override_endpoint": {
+      "default": false,
+      "description": "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+      "title": "Endpoint Overwrite",
+      "type": "boolean"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to",
+      "enum": [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "fips-us-east-1",
+        "fips-us-east-2",
+        "fips-us-west-1",
+        "fips-us-west-2",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "cn-north-1",
+        "cn-northwest-1",
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-iso-east-1",
+        "us-iso-west-1",
+        "us-isob-east-1"
+      ],
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "aws_stream_iterator_type": {
+      "default": "FROM_LATEST",
+      "description": "Defines where in the DynamoDB stream to start getting records. Note that using FROM_START can cause a significant delay before the stream has caught up to real-time. There are 2 enums and the value can be one of FROM_LATEST and FROM_START",
+      "title": "Stream Iterator Type",
+      "type": "string"
+    },
+    "aws_table": {
+      "description": "Name of the DynamoDB table to look at",
+      "title": "Table",
+      "type": "string"
+    },
+    "aws_uri_endpoint_override": {
+      "description": "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+      "title": "Overwrite Endpoint URI",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_table",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_kinesis_sink_0.1.json
+++ b/schemas/aws_kinesis_sink_0.1.json
@@ -1,0 +1,226 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      },
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_override_endpoint": {
+      "default": false,
+      "description": "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+      "title": "Endpoint Overwrite",
+      "type": "boolean"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to",
+      "enum": [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "fips-us-east-1",
+        "fips-us-east-2",
+        "fips-us-west-1",
+        "fips-us-west-2",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "cn-north-1",
+        "cn-northwest-1",
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-iso-east-1",
+        "us-iso-west-1",
+        "us-isob-east-1"
+      ],
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "aws_stream": {
+      "description": "The Kinesis stream that you want to access (needs to be created in advance)",
+      "title": "Stream Name",
+      "type": "string"
+    },
+    "aws_uri_endpoint_override": {
+      "description": "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+      "title": "Overwrite Endpoint URI",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        },
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_stream",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_kinesis_source_0.1.json
+++ b/schemas/aws_kinesis_source_0.1.json
@@ -1,0 +1,197 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      },
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_delay": {
+      "default": 500,
+      "description": "Milliseconds before the next poll of the selected stream",
+      "title": "Delay",
+      "type": "integer"
+    },
+    "aws_override_endpoint": {
+      "default": false,
+      "description": "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+      "title": "Endpoint Overwrite",
+      "type": "boolean"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to",
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "aws_stream": {
+      "description": "The Kinesis stream that you want to access (needs to be created in advance)",
+      "title": "Stream Name",
+      "type": "string"
+    },
+    "aws_uri_endpoint_override": {
+      "description": "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+      "title": "Overwrite Endpoint URI",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        },
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_stream",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_lambda_sink_0.1.json
+++ b/schemas/aws_lambda_sink_0.1.json
@@ -1,0 +1,196 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_function": {
+      "description": "The Lambda Function name",
+      "title": "Function Name",
+      "type": "string"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to",
+      "enum": [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "fips-us-east-1",
+        "fips-us-east-2",
+        "fips-us-west-1",
+        "fips-us-west-2",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "cn-north-1",
+        "cn-northwest-1",
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-iso-east-1",
+        "us-iso-west-1",
+        "us-isob-east-1"
+      ],
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_function",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_redshift_sink_0.1.json
+++ b/schemas/aws_redshift_sink_0.1.json
@@ -1,0 +1,163 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "sql_database_name": {
+      "description": "The Database Name we are pointing",
+      "title": "Database Name",
+      "type": "string"
+    },
+    "sql_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured AWS Redshift Database",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the sql_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "sql_query": {
+      "description": "The Query to execute against the AWS Redshift Database",
+      "example": "INSERT INTO accounts (username,city) VALUES (:#username,:#city)",
+      "title": "Query",
+      "type": "string"
+    },
+    "sql_server_name": {
+      "description": "Server Name for the data source",
+      "example": "localhost",
+      "title": "Server Name",
+      "type": "string"
+    },
+    "sql_server_port": {
+      "default": 5439,
+      "description": "Server Port for the data source",
+      "title": "Server Port",
+      "type": "string"
+    },
+    "sql_username": {
+      "description": "The username to use for accessing a secured AWS Redshift Database",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    }
+  },
+  "required": [
+    "sql_server_name",
+    "sql_username",
+    "sql_password",
+    "sql_query",
+    "sql_database_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_redshift_source_0.1.json
+++ b/schemas/aws_redshift_source_0.1.json
@@ -1,0 +1,175 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "sql_consumed_query": {
+      "description": "A query to run on a tuple consumed",
+      "example": "DELETE FROM accounts where user_id = :#user_id",
+      "title": "Consumed Query",
+      "type": "string"
+    },
+    "sql_database_name": {
+      "description": "The Database Name we are pointing",
+      "title": "Database Name",
+      "type": "string"
+    },
+    "sql_delay": {
+      "default": 500,
+      "description": "Milliseconds before the next poll from database",
+      "title": "Delay",
+      "type": "integer"
+    },
+    "sql_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured AWS Redshift Database",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the sql_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "sql_query": {
+      "description": "The Query to execute against the AWS Redshift Database",
+      "example": "INSERT INTO accounts (username,city) VALUES (:#username,:#city)",
+      "title": "Query",
+      "type": "string"
+    },
+    "sql_server_name": {
+      "description": "Server Name for the data source",
+      "example": "localhost",
+      "title": "Server Name",
+      "type": "string"
+    },
+    "sql_server_port": {
+      "default": 5439,
+      "description": "Server Port for the data source",
+      "title": "Server Port",
+      "type": "string"
+    },
+    "sql_username": {
+      "description": "The username to use for accessing a secured AWS Redshift Database",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    }
+  },
+  "required": [
+    "sql_server_name",
+    "sql_username",
+    "sql_password",
+    "sql_query",
+    "sql_database_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_s3_sink_0.1.json
+++ b/schemas/aws_s3_sink_0.1.json
@@ -1,0 +1,218 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS.",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_auto_create_bucket": {
+      "default": false,
+      "description": "Setting the autocreation of the S3 bucket bucketName.",
+      "title": "Autocreate Bucket",
+      "type": "boolean"
+    },
+    "aws_bucket_name_or_arn": {
+      "description": "The S3 Bucket name or ARN.",
+      "title": "Bucket Name",
+      "type": "string"
+    },
+    "aws_key_name": {
+      "description": "The key name for saving an element in the bucket.",
+      "title": "Key Name",
+      "type": "string"
+    },
+    "aws_override_endpoint": {
+      "default": false,
+      "description": "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+      "title": "Endpoint Overwrite",
+      "type": "boolean"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to.",
+      "enum": [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "fips-us-east-1",
+        "fips-us-east-2",
+        "fips-us-west-1",
+        "fips-us-west-2",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "cn-north-1",
+        "cn-northwest-1",
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-iso-east-1",
+        "us-iso-west-1",
+        "us-isob-east-1"
+      ],
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS.",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "aws_uri_endpoint_override": {
+      "description": "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+      "title": "Overwrite Endpoint URI",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_bucket_name_or_arn",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_s3_source_0.1.json
+++ b/schemas/aws_s3_source_0.1.json
@@ -1,0 +1,243 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_auto_create_bucket": {
+      "default": false,
+      "description": "Setting the autocreation of the S3 bucket bucketName.",
+      "title": "Autocreate Bucket",
+      "type": "boolean"
+    },
+    "aws_bucket_name_or_arn": {
+      "description": "The S3 Bucket name or ARN",
+      "title": "Bucket Name",
+      "type": "string"
+    },
+    "aws_delay": {
+      "default": 500,
+      "description": "Milliseconds before the next poll of the selected bucket",
+      "title": "Delay",
+      "type": "integer"
+    },
+    "aws_delete_after_read": {
+      "default": true,
+      "description": "Delete objects after consuming them",
+      "title": "Auto-delete Objects",
+      "type": "boolean"
+    },
+    "aws_ignore_body": {
+      "default": false,
+      "description": "If it is true, the S3 Object Body will be ignored completely, if it is set to false the S3 Object will be put in the body. Setting this to true, will override any behavior defined by includeBody option.",
+      "title": "Ignore Body",
+      "type": "boolean"
+    },
+    "aws_include_body": {
+      "default": true,
+      "description": "If it is true, the exchange will be consumed and put into the body and closed. If false the S3Object stream will be put raw into the body and the headers will be set with the S3 object metadata.",
+      "title": "Include Body",
+      "type": "boolean"
+    },
+    "aws_override_endpoint": {
+      "default": false,
+      "description": "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+      "title": "Endpoint Overwrite",
+      "type": "boolean"
+    },
+    "aws_prefix": {
+      "description": "The AWS S3 bucket prefix to consider while searching",
+      "example": "folder/",
+      "title": "Prefix",
+      "type": "string"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to",
+      "enum": [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "fips-us-east-1",
+        "fips-us-east-2",
+        "fips-us-west-1",
+        "fips-us-west-2",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "cn-north-1",
+        "cn-northwest-1",
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-iso-east-1",
+        "us-iso-west-1",
+        "us-isob-east-1"
+      ],
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "aws_uri_endpoint_override": {
+      "description": "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+      "title": "Overwrite Endpoint URI",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_bucket_name_or_arn",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_ses_sink_0.1.json
+++ b/schemas/aws_ses_sink_0.1.json
@@ -1,0 +1,197 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS.",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_from": {
+      "description": "From address",
+      "example": "user@example.com",
+      "title": "From",
+      "type": "string"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to.",
+      "enum": [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "fips-us-east-1",
+        "fips-us-east-2",
+        "fips-us-west-1",
+        "fips-us-west-2",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "cn-north-1",
+        "cn-northwest-1",
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-iso-east-1",
+        "us-iso-west-1",
+        "us-isob-east-1"
+      ],
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS.",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_from",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_sns_sink_0.1.json
+++ b/schemas/aws_sns_sink_0.1.json
@@ -1,0 +1,213 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_auto_create_topic": {
+      "default": false,
+      "description": "Setting the autocreation of the SNS topic.",
+      "title": "Autocreate Topic",
+      "type": "boolean"
+    },
+    "aws_override_endpoint": {
+      "default": false,
+      "description": "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+      "title": "Endpoint Overwrite",
+      "type": "boolean"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to",
+      "enum": [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "fips-us-east-1",
+        "fips-us-east-2",
+        "fips-us-west-1",
+        "fips-us-west-2",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "cn-north-1",
+        "cn-northwest-1",
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-iso-east-1",
+        "us-iso-west-1",
+        "us-isob-east-1"
+      ],
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "aws_topic_name_or_arn": {
+      "description": "The SQS Topic name or ARN",
+      "title": "Topic Name",
+      "type": "string"
+    },
+    "aws_uri_endpoint_override": {
+      "description": "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+      "title": "Overwrite Endpoint URI",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_topic_name_or_arn",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_sqs_sink_0.1.json
+++ b/schemas/aws_sqs_sink_0.1.json
@@ -1,0 +1,226 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_amazon_a_w_s_host": {
+      "default": "amazonaws.com",
+      "description": "The hostname of the Amazon AWS cloud.",
+      "title": "AWS Host",
+      "type": "string"
+    },
+    "aws_auto_create_queue": {
+      "default": false,
+      "description": "Setting the autocreation of the SQS queue.",
+      "title": "Autocreate Queue",
+      "type": "boolean"
+    },
+    "aws_override_endpoint": {
+      "default": false,
+      "description": "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+      "title": "Endpoint Overwrite",
+      "type": "boolean"
+    },
+    "aws_protocol": {
+      "default": "https",
+      "description": "The underlying protocol used to communicate with SQS",
+      "example": "http or https",
+      "title": "Protocol",
+      "type": "string"
+    },
+    "aws_queue_name_or_arn": {
+      "description": "The SQS Queue name or ARN",
+      "title": "Queue Name",
+      "type": "string"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to",
+      "enum": [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "fips-us-east-1",
+        "fips-us-east-2",
+        "fips-us-west-1",
+        "fips-us-west-2",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "cn-north-1",
+        "cn-northwest-1",
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-iso-east-1",
+        "us-iso-west-1",
+        "us-isob-east-1"
+      ],
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "aws_uri_endpoint_override": {
+      "description": "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+      "title": "Overwrite Endpoint URI",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_queue_name_or_arn",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/aws_sqs_source_0.1.json
+++ b/schemas/aws_sqs_source_0.1.json
@@ -1,0 +1,243 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "aws_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from AWS",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "aws_amazon_a_w_s_host": {
+      "default": "amazonaws.com",
+      "description": "The hostname of the Amazon AWS cloud.",
+      "title": "AWS Host",
+      "type": "string"
+    },
+    "aws_auto_create_queue": {
+      "default": false,
+      "description": "Setting the autocreation of the SQS queue.",
+      "title": "Autocreate Queue",
+      "type": "boolean"
+    },
+    "aws_delay": {
+      "default": 500,
+      "description": "Milliseconds before the next poll of the selected stream",
+      "title": "Delay",
+      "type": "integer"
+    },
+    "aws_delete_after_read": {
+      "default": true,
+      "description": "Delete messages after consuming them",
+      "title": "Auto-delete Messages",
+      "type": "boolean"
+    },
+    "aws_override_endpoint": {
+      "default": false,
+      "description": "Set the need for overiding the endpoint URI. This option needs to be used in combination with uriEndpointOverride setting.",
+      "title": "Endpoint Overwrite",
+      "type": "boolean"
+    },
+    "aws_protocol": {
+      "default": "https",
+      "description": "The underlying protocol used to communicate with SQS",
+      "example": "http or https",
+      "title": "Protocol",
+      "type": "string"
+    },
+    "aws_queue_name_or_arn": {
+      "description": "The SQS Queue Name or ARN",
+      "title": "Queue Name",
+      "type": "string"
+    },
+    "aws_queue_u_r_l": {
+      "description": "The full SQS Queue URL (required if using KEDA)",
+      "title": "Queue URL",
+      "type": "string"
+    },
+    "aws_region": {
+      "description": "The AWS region to connect to",
+      "enum": [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "fips-us-east-1",
+        "fips-us-east-2",
+        "fips-us-west-1",
+        "fips-us-west-2",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "cn-north-1",
+        "cn-northwest-1",
+        "us-gov-east-1",
+        "us-gov-west-1",
+        "us-iso-east-1",
+        "us-iso-west-1",
+        "us-isob-east-1"
+      ],
+      "example": "eu-west-1",
+      "title": "AWS Region",
+      "type": "string"
+    },
+    "aws_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from AWS",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the aws_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "aws_uri_endpoint_override": {
+      "description": "Set the overriding endpoint URI. This option needs to be used in combination with overrideEndpoint option.",
+      "title": "Overwrite Endpoint URI",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "aws_queue_name_or_arn",
+    "aws_region",
+    "kafka_topic",
+    "aws_access_key",
+    "aws_secret_key"
+  ],
+  "type": "object"
+}

--- a/schemas/azure_eventhubs_sink_0.1.json
+++ b/schemas/azure_eventhubs_sink_0.1.json
@@ -1,0 +1,149 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "azure_eventhub_name": {
+      "description": "The eventhub name",
+      "title": "Eventhubs Name",
+      "type": "string"
+    },
+    "azure_namespace_name": {
+      "description": "The eventhubs namespace",
+      "title": "Eventhubs Namespace",
+      "type": "string"
+    },
+    "azure_shared_access_key": {
+      "oneOf": [
+        {
+          "description": "The key for EventHubs SAS key name",
+          "format": "password",
+          "title": "Share Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the azure_shared_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Share Access Key",
+      "x-group": "credentials"
+    },
+    "azure_shared_access_name": {
+      "description": "EventHubs SAS key name",
+      "title": "Share Access Name",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "azure_namespace_name",
+    "azure_eventhub_name",
+    "azure_shared_access_name",
+    "azure_shared_access_key",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/azure_eventhubs_source_0.1.json
+++ b/schemas/azure_eventhubs_source_0.1.json
@@ -1,0 +1,179 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "azure_blob_access_key": {
+      "oneOf": [
+        {
+          "description": "The key for Azure Storage Blob service associated with the Blob account name",
+          "format": "password",
+          "title": "Azure Storage Blob Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the azure_blob_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Azure Storage Blob Access Key",
+      "x-group": "credentials"
+    },
+    "azure_blob_account_name": {
+      "description": "The name of the storage blob account to be use",
+      "title": "Azure Storage Blob Account Name",
+      "type": "string"
+    },
+    "azure_blob_container_name": {
+      "description": "The name of the storage blob container to be use",
+      "title": "Azure Storage Blob Container Name",
+      "type": "string"
+    },
+    "azure_eventhub_name": {
+      "description": "The eventhub name",
+      "title": "Eventhubs Name",
+      "type": "string"
+    },
+    "azure_namespace_name": {
+      "description": "The eventhubs namespace",
+      "title": "Eventhubs Namespace",
+      "type": "string"
+    },
+    "azure_shared_access_key": {
+      "oneOf": [
+        {
+          "description": "The key for EventHubs SAS key name",
+          "format": "password",
+          "title": "Share Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the azure_shared_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Share Access Key",
+      "x-group": "credentials"
+    },
+    "azure_shared_access_name": {
+      "description": "EventHubs SAS key name",
+      "title": "Share Access Name",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "azure_namespace_name",
+    "azure_eventhub_name",
+    "azure_shared_access_name",
+    "azure_shared_access_key",
+    "azure_blob_account_name",
+    "azure_blob_access_key",
+    "azure_blob_container_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/azure_storage_blob_changefeed_source_0.1.json
+++ b/schemas/azure_storage_blob_changefeed_source_0.1.json
@@ -1,0 +1,144 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "azure_access_key": {
+      "oneOf": [
+        {
+          "description": "The Azure Storage Blob access Key.",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the azure_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "azure_account_name": {
+      "description": "The Azure Storage Blob account name.",
+      "title": "Account Name",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "azure_period": {
+      "default": 10000,
+      "description": "The interval between fetches to the Azure Storage Changefeed in milliseconds",
+      "title": "Period between Polls",
+      "type": "integer"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "azure_period",
+    "azure_account_name",
+    "azure_access_key",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/azure_storage_blob_sink_0.1.json
+++ b/schemas/azure_storage_blob_sink_0.1.json
@@ -1,0 +1,149 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "azure_access_key": {
+      "oneOf": [
+        {
+          "description": "The Azure Storage Blob access Key.",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the azure_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "azure_account_name": {
+      "description": "The Azure Storage Blob account name.",
+      "title": "Account Name",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "azure_container_name": {
+      "description": "The Azure Storage Blob container name.",
+      "title": "Container Name",
+      "type": "string"
+    },
+    "azure_operation": {
+      "default": "uploadBlockBlob",
+      "description": "The operation to perform.",
+      "title": "Operation name",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "azure_account_name",
+    "azure_container_name",
+    "azure_access_key",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/azure_storage_blob_source_0.1.json
+++ b/schemas/azure_storage_blob_source_0.1.json
@@ -1,0 +1,150 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "azure_access_key": {
+      "oneOf": [
+        {
+          "description": "The Azure Storage Blob access Key.",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the azure_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "azure_account_name": {
+      "description": "The Azure Storage Blob account name.",
+      "title": "Account Name",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "azure_container_name": {
+      "description": "The Azure Storage Blob container name.",
+      "title": "Container Name",
+      "type": "string"
+    },
+    "azure_period": {
+      "default": 10000,
+      "description": "The interval between fetches to the Azure Storage Container in milliseconds",
+      "title": "Period between Polls",
+      "type": "integer"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "azure_period",
+    "azure_account_name",
+    "azure_container_name",
+    "azure_access_key",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/azure_storage_queue_sink_0.1.json
+++ b/schemas/azure_storage_queue_sink_0.1.json
@@ -1,0 +1,143 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "azure_access_key": {
+      "oneOf": [
+        {
+          "description": "The Azure Storage Queue access Key.",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the azure_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "azure_account_name": {
+      "description": "The Azure Storage Queue account name.",
+      "title": "Account Name",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "azure_queue_name": {
+      "description": "The Azure Storage Queue container name.",
+      "title": "Queue Name",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "azure_account_name",
+    "azure_queue_name",
+    "azure_access_key",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/azure_storage_queue_source_0.1.json
+++ b/schemas/azure_storage_queue_source_0.1.json
@@ -1,0 +1,149 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "azure_access_key": {
+      "oneOf": [
+        {
+          "description": "The Azure Storage Queue access Key.",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the azure_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "azure_account_name": {
+      "description": "The Azure Storage Queue account name.",
+      "title": "Account Name",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "azure_max_messages": {
+      "default": 1,
+      "description": "Maximum number of messages to get, if there are less messages exist in the queue than requested all the messages will be returned. By default it will consider 1 message to be retrieved, the allowed range is 1 to 32 messages.",
+      "title": "Maximum Messages",
+      "type": "integer"
+    },
+    "azure_queue_name": {
+      "description": "The Azure Storage Queue container name.",
+      "title": "Queue Name",
+      "type": "string"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "azure_account_name",
+    "azure_queue_name",
+    "azure_access_key",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/cassandra_sink_0.1.json
+++ b/schemas/cassandra_sink_0.1.json
@@ -1,0 +1,174 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "cassandra_connection_host": {
+      "description": "Hostname(s) cassandra server(s). Multiple hosts can be separated by comma.",
+      "example": "localhost",
+      "title": "Connection Host",
+      "type": "string"
+    },
+    "cassandra_connection_port": {
+      "description": "Port number of cassandra server(s)",
+      "example": 9042,
+      "title": "Connection Port",
+      "type": "string"
+    },
+    "cassandra_consistency_level": {
+      "default": "ANY",
+      "description": "Consistency level to use. The value can be one of ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, LOCAL_ONE",
+      "title": "Consistency Level",
+      "type": "string"
+    },
+    "cassandra_keyspace": {
+      "description": "Keyspace to use",
+      "example": "customers",
+      "title": "Keyspace",
+      "type": "string"
+    },
+    "cassandra_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured Cassandra Cluster",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the cassandra_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "cassandra_prepare_statements": {
+      "default": true,
+      "description": "Whether to use PreparedStatements or regular Statements as the query.",
+      "title": "Prepare Statements",
+      "type": "boolean"
+    },
+    "cassandra_query": {
+      "description": "The query to execute against the Cassandra cluster table",
+      "title": "Query",
+      "type": "string"
+    },
+    "cassandra_username": {
+      "description": "The username to use for accessing a secured Cassandra Cluster",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "cassandra_connection_host",
+    "cassandra_connection_port",
+    "cassandra_keyspace",
+    "cassandra_query",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/cassandra_source_0.1.json
+++ b/schemas/cassandra_source_0.1.json
@@ -1,0 +1,174 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "cassandra_connection_host": {
+      "description": "Hostname(s) cassandra server(s). Multiple hosts can be separated by comma.",
+      "example": "localhost",
+      "title": "Connection Host",
+      "type": "string"
+    },
+    "cassandra_connection_port": {
+      "description": "Port number of cassandra server(s)",
+      "example": 9042,
+      "title": "Connection Port",
+      "type": "string"
+    },
+    "cassandra_consistency_level": {
+      "default": "QUORUM",
+      "description": "Consistency level to use. The value can be one of ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, LOCAL_ONE",
+      "title": "Consistency Level",
+      "type": "string"
+    },
+    "cassandra_keyspace": {
+      "description": "Keyspace to use",
+      "example": "customers",
+      "title": "Keyspace",
+      "type": "string"
+    },
+    "cassandra_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured Cassandra Cluster",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the cassandra_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "cassandra_query": {
+      "description": "The query to execute against the Cassandra cluster table",
+      "title": "Query",
+      "type": "string"
+    },
+    "cassandra_result_strategy": {
+      "default": "ALL",
+      "description": "The strategy to convert the result set of the query. Possible values are ALL, ONE, LIMIT_10, LIMIT_100...",
+      "title": "Result Strategy",
+      "type": "string"
+    },
+    "cassandra_username": {
+      "description": "The username to use for accessing a secured Cassandra Cluster",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "cassandra_connection_host",
+    "cassandra_connection_port",
+    "cassandra_keyspace",
+    "cassandra_query",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/data_generator_0.1.json
+++ b/schemas/data_generator_0.1.json
@@ -1,0 +1,131 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "timer_content_type": {
+      "default": "text/plain",
+      "description": "The content type of the message being generated",
+      "title": "Content Type",
+      "type": "string"
+    },
+    "timer_message": {
+      "description": "The message to generate",
+      "example": "hello world",
+      "title": "Message",
+      "type": "string"
+    },
+    "timer_period": {
+      "default": 1000,
+      "description": "The interval between two events in milliseconds",
+      "title": "Period",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "timer_message",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/debezium-mongodb-1.9.0.Alpha2.json
+++ b/schemas/debezium-mongodb-1.9.0.Alpha2.json
@@ -1,0 +1,177 @@
+{
+  "$defs": {
+    "serializer": {
+      "default": "JSON",
+      "enum": [
+        "JSON",
+        "JSON without schema"
+      ],
+      "type": "string"
+    }
+  },
+  "additionalProperties": true,
+  "properties": {
+    "collection.exclude.list": {
+      "description": "A comma-separated list of regular expressions that match the collection names for which changes are to be excluded",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "collection.exclude.list"
+    },
+    "collection.include.list": {
+      "description": "A comma-separated list of regular expressions that match the collection names for which changes are to be captured",
+      "format": "list,regex",
+      "title": "Include Collections",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "collection.include.list"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message key.",
+          "title": "Kafka Message Key Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.key"
+        },
+        "value": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message value.",
+          "title": "Kafka Message Value Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.value"
+        }
+      },
+      "type": "object"
+    },
+    "database.exclude.list": {
+      "description": "A comma-separated list of regular expressions that match the database names for which changes are to be excluded",
+      "format": "list,regex",
+      "title": "Exclude Databases",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "database.exclude.list"
+    },
+    "database.include.list": {
+      "description": "A comma-separated list of regular expressions that match the database names for which changes are to be captured",
+      "format": "list,regex",
+      "title": "Include Databases",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "database.include.list"
+    },
+    "field.exclude.list": {
+      "description": "A comma-separated list of the fully-qualified names of fields that should be excluded from change event message values",
+      "title": "Exclude Fields",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "field.exclude.list"
+    },
+    "max.batch.size": {
+      "default": 2048,
+      "description": "Maximum size of each batch of source records. Defaults to 2048.",
+      "format": "int32",
+      "title": "Change event batch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.batch.size"
+    },
+    "max.queue.size": {
+      "default": 8192,
+      "description": "Maximum size of the queue for change events read from the database log but not yet recorded or forwarded. Defaults to 8192, and should always be larger than the maximum batch size.",
+      "format": "int32",
+      "title": "Change event buffer size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.queue.size"
+    },
+    "mongodb.authsource": {
+      "default": "admin",
+      "description": "Database containing user credentials.",
+      "title": "Credentials Database",
+      "type": "string",
+      "x-category": "CONNECTION_ADVANCED",
+      "x-name": "mongodb.authsource"
+    },
+    "mongodb.hosts": {
+      "description": "The hostname and port pairs (in the form 'host' or 'host:port') of the MongoDB server(s) in the replica set.",
+      "format": "list,regex",
+      "title": "Hosts",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "mongodb.hosts"
+    },
+    "mongodb.name": {
+      "description": "Unique name that identifies the MongoDB replica set or cluster and all recorded offsets, and that is used as a prefix for all schemas and topics. Each distinct MongoDB installation should have a separate namespace and monitored by at most one Debezium connector.",
+      "nullable": false,
+      "title": "Namespace",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "mongodb.name"
+    },
+    "mongodb.password": {
+      "description": "Password to be used when connecting to MongoDB, if necessary.",
+      "oneOf": [
+        {
+          "description": "Password of the database user to be used when connecting to the database.",
+          "format": "password",
+          "type": "string"
+        },
+        {
+          "additionalProperties": true,
+          "description": "An opaque reference to the password.",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-category": "CONNECTION",
+      "x-name": "mongodb.password"
+    },
+    "mongodb.ssl.enabled": {
+      "default": false,
+      "description": "Should connector use SSL to connect to MongoDB instances",
+      "title": "Enable SSL connection to MongoDB",
+      "type": "boolean",
+      "x-category": "CONNECTION_ADVANCED_SSL",
+      "x-name": "mongodb.ssl.enabled"
+    },
+    "mongodb.user": {
+      "description": "Database user for connecting to MongoDB, if necessary.",
+      "title": "User",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "mongodb.user"
+    },
+    "query.fetch.size": {
+      "default": 0,
+      "description": "The maximum number of records that should be loaded into memory while streaming.  A value of `0` uses the default JDBC fetch size.",
+      "format": "int32",
+      "title": "Query fetch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "query.fetch.size"
+    },
+    "snapshot.mode": {
+      "default": "initial",
+      "description": "The criteria for running a snapshot upon startup of the connector. Options include: 'initial' (the default) to specify the connector should always perform an initial sync when required; 'never' to specify the connector should never perform an initial sync ",
+      "enum": [
+        "never",
+        "initial"
+      ],
+      "title": "Snapshot mode",
+      "type": "string",
+      "x-category": "CONNECTOR_SNAPSHOT",
+      "x-name": "snapshot.mode"
+    }
+  },
+  "required": [
+    "mongodb.name"
+  ],
+  "title": "Debezium MongoDB Connector",
+  "type": "object",
+  "x-className": "io.debezium.connector.mongodb.MongoDbConnector",
+  "x-connector-id": "mongodb",
+  "x-version": "1.9.0.Alpha2"
+}

--- a/schemas/debezium-mongodb-1.9.3.Final.json
+++ b/schemas/debezium-mongodb-1.9.3.Final.json
@@ -1,0 +1,177 @@
+{
+  "$defs": {
+    "serializer": {
+      "default": "JSON",
+      "enum": [
+        "JSON",
+        "JSON without schema"
+      ],
+      "type": "string"
+    }
+  },
+  "additionalProperties": true,
+  "properties": {
+    "collection.exclude.list": {
+      "description": "A comma-separated list of regular expressions that match the collection names for which changes are to be excluded",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "collection.exclude.list"
+    },
+    "collection.include.list": {
+      "description": "A comma-separated list of regular expressions that match the collection names for which changes are to be captured",
+      "format": "list,regex",
+      "title": "Include Collections",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "collection.include.list"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message key.",
+          "title": "Kafka Message Key Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.key"
+        },
+        "value": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message value.",
+          "title": "Kafka Message Value Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.value"
+        }
+      },
+      "type": "object"
+    },
+    "database.exclude.list": {
+      "description": "A comma-separated list of regular expressions that match the database names for which changes are to be excluded",
+      "format": "list,regex",
+      "title": "Exclude Databases",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "database.exclude.list"
+    },
+    "database.include.list": {
+      "description": "A comma-separated list of regular expressions that match the database names for which changes are to be captured",
+      "format": "list,regex",
+      "title": "Include Databases",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "database.include.list"
+    },
+    "field.exclude.list": {
+      "description": "A comma-separated list of the fully-qualified names of fields that should be excluded from change event message values",
+      "title": "Exclude Fields",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "field.exclude.list"
+    },
+    "max.batch.size": {
+      "default": 2048,
+      "description": "Maximum size of each batch of source records. Defaults to 2048.",
+      "format": "int32",
+      "title": "Change event batch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.batch.size"
+    },
+    "max.queue.size": {
+      "default": 8192,
+      "description": "Maximum size of the queue for change events read from the database log but not yet recorded or forwarded. Defaults to 8192, and should always be larger than the maximum batch size.",
+      "format": "int32",
+      "title": "Change event buffer size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.queue.size"
+    },
+    "mongodb.authsource": {
+      "default": "admin",
+      "description": "Database containing user credentials.",
+      "title": "Credentials Database",
+      "type": "string",
+      "x-category": "CONNECTION_ADVANCED",
+      "x-name": "mongodb.authsource"
+    },
+    "mongodb.hosts": {
+      "description": "The hostname and port pairs (in the form 'host' or 'host:port') of the MongoDB server(s) in the replica set.",
+      "format": "list,regex",
+      "title": "Hosts",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "mongodb.hosts"
+    },
+    "mongodb.name": {
+      "description": "Unique name that identifies the MongoDB replica set or cluster and all recorded offsets, and that is used as a prefix for all schemas and topics. Each distinct MongoDB installation should have a separate namespace and monitored by at most one Debezium connector.",
+      "nullable": false,
+      "title": "Namespace",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "mongodb.name"
+    },
+    "mongodb.password": {
+      "description": "Password to be used when connecting to MongoDB, if necessary.",
+      "oneOf": [
+        {
+          "description": "Password of the database user to be used when connecting to the database.",
+          "format": "password",
+          "type": "string"
+        },
+        {
+          "additionalProperties": true,
+          "description": "An opaque reference to the password.",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-category": "CONNECTION",
+      "x-name": "mongodb.password"
+    },
+    "mongodb.ssl.enabled": {
+      "default": false,
+      "description": "Should connector use SSL to connect to MongoDB instances",
+      "title": "Enable SSL connection to MongoDB",
+      "type": "boolean",
+      "x-category": "CONNECTION_ADVANCED_SSL",
+      "x-name": "mongodb.ssl.enabled"
+    },
+    "mongodb.user": {
+      "description": "Database user for connecting to MongoDB, if necessary.",
+      "title": "User",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "mongodb.user"
+    },
+    "query.fetch.size": {
+      "default": 0,
+      "description": "The maximum number of records that should be loaded into memory while streaming.  A value of `0` uses the default JDBC fetch size.",
+      "format": "int32",
+      "title": "Query fetch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "query.fetch.size"
+    },
+    "snapshot.mode": {
+      "default": "initial",
+      "description": "The criteria for running a snapshot upon startup of the connector. Options include: 'initial' (the default) to specify the connector should always perform an initial sync when required; 'never' to specify the connector should never perform an initial sync ",
+      "enum": [
+        "never",
+        "initial"
+      ],
+      "title": "Snapshot mode",
+      "type": "string",
+      "x-category": "CONNECTOR_SNAPSHOT",
+      "x-name": "snapshot.mode"
+    }
+  },
+  "required": [
+    "mongodb.name"
+  ],
+  "title": "Debezium MongoDB Connector",
+  "type": "object",
+  "x-className": "io.debezium.connector.mongodb.MongoDbConnector",
+  "x-connector-id": "mongodb",
+  "x-version": "1.9.3.Final"
+}

--- a/schemas/debezium-mysql-1.9.0.Alpha2.json
+++ b/schemas/debezium-mysql-1.9.0.Alpha2.json
@@ -1,0 +1,219 @@
+{
+  "$defs": {
+    "serializer": {
+      "default": "JSON",
+      "enum": [
+        "JSON",
+        "JSON without schema"
+      ],
+      "type": "string"
+    }
+  },
+  "additionalProperties": true,
+  "properties": {
+    "column.exclude.list": {
+      "description": "Regular expressions matching columns to exclude from change events",
+      "format": "list,regex",
+      "title": "Exclude Columns",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "column.exclude.list"
+    },
+    "column.include.list": {
+      "description": "Regular expressions matching columns to include in change events",
+      "format": "list,regex",
+      "title": "Include Columns",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "column.include.list"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message key.",
+          "title": "Kafka Message Key Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.key"
+        },
+        "value": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message value.",
+          "title": "Kafka Message Value Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.value"
+        }
+      },
+      "type": "object"
+    },
+    "database.exclude.list": {
+      "description": "A comma-separated list of regular expressions that match database names to be excluded from monitoring",
+      "format": "list,regex",
+      "title": "Exclude Databases",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "database.exclude.list"
+    },
+    "database.hostname": {
+      "description": "Resolvable hostname or IP address of the database server.",
+      "nullable": false,
+      "title": "Hostname",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.hostname"
+    },
+    "database.include.list": {
+      "description": "The databases for which changes are to be captured",
+      "format": "list,regex",
+      "title": "Include Databases",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "database.include.list"
+    },
+    "database.password": {
+      "description": "Password of the database user to be used when connecting to the database.",
+      "oneOf": [
+        {
+          "description": "Password of the database user to be used when connecting to the database.",
+          "format": "password",
+          "type": "string"
+        },
+        {
+          "additionalProperties": true,
+          "description": "An opaque reference to the password.",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-category": "CONNECTION",
+      "x-name": "database.password"
+    },
+    "database.port": {
+      "default": 3306,
+      "description": "Port of the database server.",
+      "format": "int32",
+      "title": "Port",
+      "type": "integer",
+      "x-category": "CONNECTION",
+      "x-name": "database.port"
+    },
+    "database.server.id": {
+      "default": 6327,
+      "description": "A numeric ID of this database client, which must be unique across all currently-running database processes in the cluster. This connector joins the MySQL database cluster as another server (with this unique ID) so it can read the binlog. By default, a random number is generated between 5400 and 6400.",
+      "format": "int64",
+      "nullable": false,
+      "title": "Cluster ID",
+      "type": "integer",
+      "x-category": "CONNECTION",
+      "x-name": "database.server.id"
+    },
+    "database.server.name": {
+      "description": "Unique name that identifies the database server and all recorded offsets, and that is used as a prefix for all schemas and topics. Each distinct installation should have a separate namespace and be monitored by at most one Debezium connector.",
+      "nullable": false,
+      "title": "Namespace",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.server.name"
+    },
+    "database.user": {
+      "description": "Name of the database user to be used when connecting to the database.",
+      "nullable": false,
+      "title": "User",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.user"
+    },
+    "decimal.handling.mode": {
+      "default": "precise",
+      "description": "Specify how DECIMAL and NUMERIC columns should be represented in change events, including:'precise' (the default) uses java.math.BigDecimal to represent values, which are encoded in the change events using a binary representation and Kafka Connect's 'org.apache.kafka.connect.data.Decimal' type; 'string' uses string to represent values; 'double' represents values using Java's 'double', which may not offer the precision but will be far easier to use in consumers.",
+      "enum": [
+        "string",
+        "double",
+        "precise"
+      ],
+      "title": "Decimal Handling",
+      "type": "string",
+      "x-category": "CONNECTOR",
+      "x-name": "decimal.handling.mode"
+    },
+    "max.batch.size": {
+      "default": 2048,
+      "description": "Maximum size of each batch of source records. Defaults to 2048.",
+      "format": "int32",
+      "title": "Change event batch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.batch.size"
+    },
+    "max.queue.size": {
+      "default": 8192,
+      "description": "Maximum size of the queue for change events read from the database log but not yet recorded or forwarded. Defaults to 8192, and should always be larger than the maximum batch size.",
+      "format": "int32",
+      "title": "Change event buffer size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.queue.size"
+    },
+    "message.key.columns": {
+      "description": "A semicolon-separated list of expressions that match fully-qualified tables and column(s) to be used as message key. Each expression must match the pattern '<fully-qualified table name>:<key columns>',where the table names could be defined as (DB_NAME.TABLE_NAME) or (SCHEMA_NAME.TABLE_NAME), depending on the specific connector,and the key columns are a comma-separated list of columns representing the custom key. For any table without an explicit key configuration the table's primary key column(s) will be used as message key.Example: dbserver1.inventory.orderlines:orderId,orderLineId;dbserver1.inventory.orders:id",
+      "title": "Columns PK mapping",
+      "type": "string",
+      "x-category": "CONNECTOR_ADVANCED",
+      "x-name": "message.key.columns"
+    },
+    "query.fetch.size": {
+      "default": 0,
+      "description": "The maximum number of records that should be loaded into memory while streaming.  A value of `0` uses the default JDBC fetch size.",
+      "format": "int32",
+      "title": "Query fetch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "query.fetch.size"
+    },
+    "snapshot.mode": {
+      "default": "initial",
+      "description": "The criteria for running a snapshot upon startup of the connector. Options include: 'when_needed' to specify that the connector run a snapshot upon startup whenever it deems it necessary; 'schema_only' to only take a snapshot of the schema (table structures) but no actual data; 'initial' (the default) to specify the connector can run a snapshot only when no offsets are available for the logical server name; 'initial_only' same as 'initial' except the connector should stop after completing the snapshot and before it would normally read the binlog; and'never' to specify the connector should never run a snapshot and that upon first startup the connector should read from the beginning of the binlog. The 'never' mode should be used with care, and only when the binlog is known to contain all history.",
+      "enum": [
+        "never",
+        "initial_only",
+        "when_needed",
+        "initial",
+        "schema_only",
+        "schema_only_recovery"
+      ],
+      "title": "Snapshot mode",
+      "type": "string",
+      "x-category": "CONNECTOR_SNAPSHOT",
+      "x-name": "snapshot.mode"
+    },
+    "table.exclude.list": {
+      "description": "A comma-separated list of regular expressions that match the fully-qualified names of tables to be excluded from monitoring",
+      "format": "list,regex",
+      "title": "Exclude Tables",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "table.exclude.list"
+    },
+    "table.include.list": {
+      "description": "The tables for which changes are to be captured",
+      "format": "list,regex",
+      "title": "Include Tables",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "table.include.list"
+    }
+  },
+  "required": [
+    "database.hostname",
+    "database.user",
+    "database.server.name",
+    "database.server.id"
+  ],
+  "title": "Debezium MySQL Connector",
+  "type": "object",
+  "x-className": "io.debezium.connector.mysql.MySqlConnector",
+  "x-connector-id": "mysql",
+  "x-version": "1.9.0.Alpha2"
+}

--- a/schemas/debezium-mysql-1.9.3.Final.json
+++ b/schemas/debezium-mysql-1.9.3.Final.json
@@ -1,0 +1,218 @@
+{
+  "$defs": {
+    "serializer": {
+      "default": "JSON",
+      "enum": [
+        "JSON",
+        "JSON without schema"
+      ],
+      "type": "string"
+    }
+  },
+  "additionalProperties": true,
+  "properties": {
+    "column.exclude.list": {
+      "description": "Regular expressions matching columns to exclude from change events",
+      "format": "list,regex",
+      "title": "Exclude Columns",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "column.exclude.list"
+    },
+    "column.include.list": {
+      "description": "Regular expressions matching columns to include in change events",
+      "format": "list,regex",
+      "title": "Include Columns",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "column.include.list"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message key.",
+          "title": "Kafka Message Key Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.key"
+        },
+        "value": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message value.",
+          "title": "Kafka Message Value Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.value"
+        }
+      },
+      "type": "object"
+    },
+    "database.exclude.list": {
+      "description": "A comma-separated list of regular expressions that match database names to be excluded from monitoring",
+      "format": "list,regex",
+      "title": "Exclude Databases",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "database.exclude.list"
+    },
+    "database.hostname": {
+      "description": "Resolvable hostname or IP address of the database server.",
+      "nullable": false,
+      "title": "Hostname",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.hostname"
+    },
+    "database.include.list": {
+      "description": "The databases for which changes are to be captured",
+      "format": "list,regex",
+      "title": "Include Databases",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "database.include.list"
+    },
+    "database.password": {
+      "description": "Password of the database user to be used when connecting to the database.",
+      "oneOf": [
+        {
+          "description": "Password of the database user to be used when connecting to the database.",
+          "format": "password",
+          "type": "string"
+        },
+        {
+          "additionalProperties": true,
+          "description": "An opaque reference to the password.",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-category": "CONNECTION",
+      "x-name": "database.password"
+    },
+    "database.port": {
+      "default": 3306,
+      "description": "Port of the database server.",
+      "format": "int32",
+      "title": "Port",
+      "type": "integer",
+      "x-category": "CONNECTION",
+      "x-name": "database.port"
+    },
+    "database.server.id": {
+      "description": "A numeric ID of this database client, which must be unique across all currently running database processes in the cluster. This connector joins the MySQL database cluster as another server (with this unique ID) so it can read the binlog.",
+      "format": "int64",
+      "nullable": false,
+      "title": "Cluster ID",
+      "type": "integer",
+      "x-category": "CONNECTION",
+      "x-name": "database.server.id"
+    },
+    "database.server.name": {
+      "description": "Unique name that identifies the database server and all recorded offsets, and that is used as a prefix for all schemas and topics. Each distinct installation should have a separate namespace and be monitored by at most one Debezium connector.",
+      "nullable": false,
+      "title": "Namespace",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.server.name"
+    },
+    "database.user": {
+      "description": "Name of the database user to be used when connecting to the database.",
+      "nullable": false,
+      "title": "User",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.user"
+    },
+    "decimal.handling.mode": {
+      "default": "precise",
+      "description": "Specify how DECIMAL and NUMERIC columns should be represented in change events, including:'precise' (the default) uses java.math.BigDecimal to represent values, which are encoded in the change events using a binary representation and Kafka Connect's 'org.apache.kafka.connect.data.Decimal' type; 'string' uses string to represent values; 'double' represents values using Java's 'double', which may not offer the precision but will be far easier to use in consumers.",
+      "enum": [
+        "string",
+        "double",
+        "precise"
+      ],
+      "title": "Decimal Handling",
+      "type": "string",
+      "x-category": "CONNECTOR",
+      "x-name": "decimal.handling.mode"
+    },
+    "max.batch.size": {
+      "default": 2048,
+      "description": "Maximum size of each batch of source records. Defaults to 2048.",
+      "format": "int32",
+      "title": "Change event batch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.batch.size"
+    },
+    "max.queue.size": {
+      "default": 8192,
+      "description": "Maximum size of the queue for change events read from the database log but not yet recorded or forwarded. Defaults to 8192, and should always be larger than the maximum batch size.",
+      "format": "int32",
+      "title": "Change event buffer size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.queue.size"
+    },
+    "message.key.columns": {
+      "description": "A semicolon-separated list of expressions that match fully-qualified tables and column(s) to be used as message key. Each expression must match the pattern '<fully-qualified table name>:<key columns>',where the table names could be defined as (DB_NAME.TABLE_NAME) or (SCHEMA_NAME.TABLE_NAME), depending on the specific connector,and the key columns are a comma-separated list of columns representing the custom key. For any table without an explicit key configuration the table's primary key column(s) will be used as message key.Example: dbserver1.inventory.orderlines:orderId,orderLineId;dbserver1.inventory.orders:id",
+      "title": "Columns PK mapping",
+      "type": "string",
+      "x-category": "CONNECTOR_ADVANCED",
+      "x-name": "message.key.columns"
+    },
+    "query.fetch.size": {
+      "default": 0,
+      "description": "The maximum number of records that should be loaded into memory while streaming.  A value of `0` uses the default JDBC fetch size.",
+      "format": "int32",
+      "title": "Query fetch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "query.fetch.size"
+    },
+    "snapshot.mode": {
+      "default": "initial",
+      "description": "The criteria for running a snapshot upon startup of the connector. Options include: 'when_needed' to specify that the connector run a snapshot upon startup whenever it deems it necessary; 'schema_only' to only take a snapshot of the schema (table structures) but no actual data; 'initial' (the default) to specify the connector can run a snapshot only when no offsets are available for the logical server name; 'initial_only' same as 'initial' except the connector should stop after completing the snapshot and before it would normally read the binlog; and'never' to specify the connector should never run a snapshot and that upon first startup the connector should read from the beginning of the binlog. The 'never' mode should be used with care, and only when the binlog is known to contain all history.",
+      "enum": [
+        "never",
+        "initial_only",
+        "when_needed",
+        "initial",
+        "schema_only",
+        "schema_only_recovery"
+      ],
+      "title": "Snapshot mode",
+      "type": "string",
+      "x-category": "CONNECTOR_SNAPSHOT",
+      "x-name": "snapshot.mode"
+    },
+    "table.exclude.list": {
+      "description": "A comma-separated list of regular expressions that match the fully-qualified names of tables to be excluded from monitoring",
+      "format": "list,regex",
+      "title": "Exclude Tables",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "table.exclude.list"
+    },
+    "table.include.list": {
+      "description": "The tables for which changes are to be captured",
+      "format": "list,regex",
+      "title": "Include Tables",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "table.include.list"
+    }
+  },
+  "required": [
+    "database.hostname",
+    "database.user",
+    "database.server.name",
+    "database.server.id"
+  ],
+  "title": "Debezium MySQL Connector",
+  "type": "object",
+  "x-className": "io.debezium.connector.mysql.MySqlConnector",
+  "x-connector-id": "mysql",
+  "x-version": "1.9.3.Final"
+}

--- a/schemas/debezium-postgres-1.9.3.Final.json
+++ b/schemas/debezium-postgres-1.9.3.Final.json
@@ -1,0 +1,246 @@
+{
+  "$defs": {
+    "serializer": {
+      "default": "JSON",
+      "enum": [
+        "JSON",
+        "JSON without schema"
+      ],
+      "type": "string"
+    }
+  },
+  "additionalProperties": true,
+  "properties": {
+    "column.exclude.list": {
+      "description": "Regular expressions matching columns to exclude from change events",
+      "format": "list,regex",
+      "title": "Exclude Columns",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "column.exclude.list"
+    },
+    "column.include.list": {
+      "description": "Regular expressions matching columns to include in change events",
+      "format": "list,regex",
+      "title": "Include Columns",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "column.include.list"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message key.",
+          "title": "Kafka Message Key Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.key"
+        },
+        "value": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message value.",
+          "title": "Kafka Message Value Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.value"
+        }
+      },
+      "type": "object"
+    },
+    "database.dbname": {
+      "description": "The name of the database from which the connector should capture changes",
+      "nullable": false,
+      "title": "Database",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.dbname"
+    },
+    "database.hostname": {
+      "description": "Resolvable hostname or IP address of the database server.",
+      "nullable": false,
+      "title": "Hostname",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.hostname"
+    },
+    "database.password": {
+      "description": "Password of the database user to be used when connecting to the database.",
+      "oneOf": [
+        {
+          "description": "Password of the database user to be used when connecting to the database.",
+          "format": "password",
+          "type": "string"
+        },
+        {
+          "additionalProperties": true,
+          "description": "An opaque reference to the password.",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-category": "CONNECTION",
+      "x-name": "database.password"
+    },
+    "database.port": {
+      "default": 5432,
+      "description": "Port of the database server.",
+      "format": "int32",
+      "title": "Port",
+      "type": "integer",
+      "x-category": "CONNECTION",
+      "x-name": "database.port"
+    },
+    "database.server.name": {
+      "description": "Unique name that identifies the database server and all recorded offsets, and that is used as a prefix for all schemas and topics. Each distinct installation should have a separate namespace and be monitored by at most one Debezium connector.",
+      "nullable": false,
+      "title": "Namespace",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.server.name"
+    },
+    "database.user": {
+      "description": "Name of the database user to be used when connecting to the database.",
+      "nullable": false,
+      "title": "User",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.user"
+    },
+    "decimal.handling.mode": {
+      "default": "precise",
+      "description": "Specify how DECIMAL and NUMERIC columns should be represented in change events, including:'precise' (the default) uses java.math.BigDecimal to represent values, which are encoded in the change events using a binary representation and Kafka Connect's 'org.apache.kafka.connect.data.Decimal' type; 'string' uses string to represent values; 'double' represents values using Java's 'double', which may not offer the precision but will be far easier to use in consumers.",
+      "enum": [
+        "string",
+        "double",
+        "precise"
+      ],
+      "title": "Decimal Handling",
+      "type": "string",
+      "x-category": "CONNECTOR",
+      "x-name": "decimal.handling.mode"
+    },
+    "max.batch.size": {
+      "default": 2048,
+      "description": "Maximum size of each batch of source records. Defaults to 2048.",
+      "format": "int32",
+      "title": "Change event batch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.batch.size"
+    },
+    "max.queue.size": {
+      "default": 8192,
+      "description": "Maximum size of the queue for change events read from the database log but not yet recorded or forwarded. Defaults to 8192, and should always be larger than the maximum batch size.",
+      "format": "int32",
+      "title": "Change event buffer size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.queue.size"
+    },
+    "message.key.columns": {
+      "description": "A semicolon-separated list of expressions that match fully-qualified tables and column(s) to be used as message key. Each expression must match the pattern '<fully-qualified table name>:<key columns>',where the table names could be defined as (DB_NAME.TABLE_NAME) or (SCHEMA_NAME.TABLE_NAME), depending on the specific connector,and the key columns are a comma-separated list of columns representing the custom key. For any table without an explicit key configuration the table's primary key column(s) will be used as message key.Example: dbserver1.inventory.orderlines:orderId,orderLineId;dbserver1.inventory.orders:id",
+      "title": "Columns PK mapping",
+      "type": "string",
+      "x-category": "CONNECTOR_ADVANCED",
+      "x-name": "message.key.columns"
+    },
+    "publication.autocreate.mode": {
+      "default": "all_tables",
+      "description": "Applies only when streaming changes using pgoutput.Determine how creation of a publication should work, the default is all_tables.DISABLED - The connector will not attempt to create a publication at all. The expectation is that the user has created the publication up-front. If the publication isn't found to exist upon startup, the connector will throw an exception and stop.ALL_TABLES - If no publication exists, the connector will create a new publication for all tables. Note this requires that the configured user has access. If the publication already exists, it will be used. i.e CREATE PUBLICATION <publication_name> FOR ALL TABLES;FILTERED - If no publication exists, the connector will create a new publication for all those tables matchingthe current filter configuration (see table/database include/exclude list properties). If the publication already exists, it will be used. i.e CREATE PUBLICATION <publication_name> FOR TABLE <tbl1, tbl2, etc>",
+      "enum": [
+        "filtered",
+        "disabled",
+        "all_tables"
+      ],
+      "title": "Publication Auto Create Mode",
+      "type": "string",
+      "x-category": "CONNECTION_ADVANCED_REPLICATION",
+      "x-name": "publication.autocreate.mode"
+    },
+    "publication.name": {
+      "default": "dbz_publication",
+      "description": "The name of the Postgres 10+ publication used for streaming changes from a plugin.Defaults to 'dbz_publication'",
+      "title": "Publication",
+      "type": "string",
+      "x-category": "CONNECTION_ADVANCED_REPLICATION",
+      "x-name": "publication.name"
+    },
+    "query.fetch.size": {
+      "default": 0,
+      "description": "The maximum number of records that should be loaded into memory while streaming.  A value of `0` uses the default JDBC fetch size.",
+      "format": "int32",
+      "title": "Query fetch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "query.fetch.size"
+    },
+    "schema.exclude.list": {
+      "description": "The schemas for which events must not be captured",
+      "format": "list,regex",
+      "title": "Exclude Schemas",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "schema.exclude.list"
+    },
+    "schema.include.list": {
+      "description": "The schemas for which events should be captured",
+      "format": "list,regex",
+      "title": "Include Schemas",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "schema.include.list"
+    },
+    "slot.name": {
+      "default": "debezium",
+      "description": "The name of the Postgres logical decoding slot created for streaming changes from a plugin.Defaults to 'debezium",
+      "title": "Slot",
+      "type": "string",
+      "x-category": "CONNECTION_ADVANCED_REPLICATION",
+      "x-name": "slot.name"
+    },
+    "snapshot.mode": {
+      "default": "initial",
+      "description": "The criteria for running a snapshot upon startup of the connector. Options include: 'always' to specify that the connector run a snapshot each time it starts up; 'initial' (the default) to specify the connector can run a snapshot only when no offsets are available for the logical server name; 'initial_only' same as 'initial' except the connector should stop after completing the snapshot and before it would normally start emitting changes;'never' to specify the connector should never run a snapshot and that upon first startup the connector should read from the last position (LSN) recorded by the server; and'exported' deprecated, use 'initial' instead; 'custom' to specify a custom class with 'snapshot.custom_class' which will be loaded and used to determine the snapshot, see docs for more details.",
+      "enum": [
+        "always",
+        "exported",
+        "never",
+        "initial_only",
+        "initial",
+        "custom"
+      ],
+      "title": "Snapshot mode",
+      "type": "string",
+      "x-category": "CONNECTOR_SNAPSHOT",
+      "x-name": "snapshot.mode"
+    },
+    "table.exclude.list": {
+      "description": "A comma-separated list of regular expressions that match the fully-qualified names of tables to be excluded from monitoring",
+      "format": "list,regex",
+      "title": "Exclude Tables",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "table.exclude.list"
+    },
+    "table.include.list": {
+      "description": "The tables for which changes are to be captured",
+      "format": "list,regex",
+      "title": "Include Tables",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "table.include.list"
+    }
+  },
+  "required": [
+    "database.server.name",
+    "database.hostname",
+    "database.user",
+    "database.dbname"
+  ],
+  "title": "Debezium PostgreSQL Connector",
+  "type": "object",
+  "x-className": "io.debezium.connector.postgresql.PostgresConnector",
+  "x-connector-id": "postgres",
+  "x-version": "1.9.3.Final"
+}

--- a/schemas/debezium-sqlserver-1.9.3.Final.json
+++ b/schemas/debezium-sqlserver-1.9.3.Final.json
@@ -1,0 +1,196 @@
+{
+  "$defs": {
+    "serializer": {
+      "default": "JSON",
+      "enum": [
+        "JSON",
+        "JSON without schema"
+      ],
+      "type": "string"
+    }
+  },
+  "additionalProperties": true,
+  "properties": {
+    "column.exclude.list": {
+      "description": "Regular expressions matching columns to exclude from change events",
+      "format": "list,regex",
+      "title": "Exclude Columns",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "column.exclude.list"
+    },
+    "column.include.list": {
+      "description": "Regular expressions matching columns to include in change events",
+      "format": "list,regex",
+      "title": "Include Columns",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "column.include.list"
+    },
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message key.",
+          "title": "Kafka Message Key Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.key"
+        },
+        "value": {
+          "$ref": "#/$defs/serializer",
+          "description": "The serialization format for the Kafka message value.",
+          "title": "Kafka Message Value Format",
+          "x-category": "CONNECTOR",
+          "x-name": "data_shape.value"
+        }
+      },
+      "type": "object"
+    },
+    "database.dbname": {
+      "description": "The name of the database from which the connector should capture changes",
+      "nullable": false,
+      "title": "Database",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.dbname"
+    },
+    "database.hostname": {
+      "description": "Resolvable hostname or IP address of the database server.",
+      "nullable": false,
+      "title": "Hostname",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.hostname"
+    },
+    "database.password": {
+      "description": "Password of the database user to be used when connecting to the database.",
+      "oneOf": [
+        {
+          "description": "Password of the database user to be used when connecting to the database.",
+          "format": "password",
+          "type": "string"
+        },
+        {
+          "additionalProperties": true,
+          "description": "An opaque reference to the password.",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-category": "CONNECTION",
+      "x-name": "database.password"
+    },
+    "database.port": {
+      "default": 1433,
+      "description": "Port of the database server.",
+      "format": "int32",
+      "title": "Port",
+      "type": "integer",
+      "x-category": "CONNECTION",
+      "x-name": "database.port"
+    },
+    "database.server.name": {
+      "description": "Unique name that identifies the database server and all recorded offsets, and that is used as a prefix for all schemas and topics. Each distinct installation should have a separate namespace and be monitored by at most one Debezium connector.",
+      "nullable": false,
+      "title": "Namespace",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.server.name"
+    },
+    "database.user": {
+      "description": "Name of the database user to be used when connecting to the database.",
+      "title": "User",
+      "type": "string",
+      "x-category": "CONNECTION",
+      "x-name": "database.user"
+    },
+    "decimal.handling.mode": {
+      "default": "precise",
+      "description": "Specify how DECIMAL and NUMERIC columns should be represented in change events, including:'precise' (the default) uses java.math.BigDecimal to represent values, which are encoded in the change events using a binary representation and Kafka Connect's 'org.apache.kafka.connect.data.Decimal' type; 'string' uses string to represent values; 'double' represents values using Java's 'double', which may not offer the precision but will be far easier to use in consumers.",
+      "enum": [
+        "string",
+        "double",
+        "precise"
+      ],
+      "title": "Decimal Handling",
+      "type": "string",
+      "x-category": "CONNECTOR",
+      "x-name": "decimal.handling.mode"
+    },
+    "max.batch.size": {
+      "default": 2048,
+      "description": "Maximum size of each batch of source records. Defaults to 2048.",
+      "format": "int32",
+      "title": "Change event batch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.batch.size"
+    },
+    "max.queue.size": {
+      "default": 8192,
+      "description": "Maximum size of the queue for change events read from the database log but not yet recorded or forwarded. Defaults to 8192, and should always be larger than the maximum batch size.",
+      "format": "int32",
+      "title": "Change event buffer size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "max.queue.size"
+    },
+    "message.key.columns": {
+      "description": "A semicolon-separated list of expressions that match fully-qualified tables and column(s) to be used as message key. Each expression must match the pattern '<fully-qualified table name>:<key columns>',where the table names could be defined as (DB_NAME.TABLE_NAME) or (SCHEMA_NAME.TABLE_NAME), depending on the specific connector,and the key columns are a comma-separated list of columns representing the custom key. For any table without an explicit key configuration the table's primary key column(s) will be used as message key.Example: dbserver1.inventory.orderlines:orderId,orderLineId;dbserver1.inventory.orders:id",
+      "title": "Columns PK mapping",
+      "type": "string",
+      "x-category": "CONNECTOR_ADVANCED",
+      "x-name": "message.key.columns"
+    },
+    "query.fetch.size": {
+      "default": 0,
+      "description": "The maximum number of records that should be loaded into memory while streaming.  A value of `0` uses the default JDBC fetch size.",
+      "format": "int32",
+      "title": "Query fetch size",
+      "type": "integer",
+      "x-category": "ADVANCED",
+      "x-name": "query.fetch.size"
+    },
+    "snapshot.mode": {
+      "default": "initial",
+      "description": "The criteria for running a snapshot upon startup of the connector. Options include: 'initial' (the default) to specify the connector should run a snapshot only when no offsets are available for the logical server name; 'schema_only' to specify the connector should run a snapshot of the schema when no offsets are available for the logical server name. ",
+      "enum": [
+        "initial_only",
+        "initial",
+        "schema_only"
+      ],
+      "title": "Snapshot mode",
+      "type": "string",
+      "x-category": "CONNECTOR_SNAPSHOT",
+      "x-name": "snapshot.mode"
+    },
+    "table.exclude.list": {
+      "description": "A comma-separated list of regular expressions that match the fully-qualified names of tables to be excluded from monitoring",
+      "format": "list,regex",
+      "title": "Exclude Tables",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "table.exclude.list"
+    },
+    "table.include.list": {
+      "description": "The tables for which changes are to be captured",
+      "format": "list,regex",
+      "title": "Include Tables",
+      "type": "string",
+      "x-category": "FILTERS",
+      "x-name": "table.include.list"
+    }
+  },
+  "required": [
+    "database.server.name",
+    "database.dbname",
+    "database.hostname"
+  ],
+  "title": "Debezium SqlSever Connector",
+  "type": "object",
+  "x-className": "io.debezium.connector.sqlserver.SqlServerConnector",
+  "x-connector-id": "sqlserver",
+  "x-version": "1.9.3.Final"
+}

--- a/schemas/elasticsearch_sink_0.1.json
+++ b/schemas/elasticsearch_sink_0.1.json
@@ -1,0 +1,161 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "elasticsearch_cluster_name": {
+      "description": "Name of the cluster.",
+      "example": "quickstart",
+      "title": "ElasticSearch Cluster Name",
+      "type": "string"
+    },
+    "elasticsearch_enable_s_s_l": {
+      "default": true,
+      "description": "Do we want to connect using SSL?",
+      "title": "Enable SSL",
+      "type": "boolean"
+    },
+    "elasticsearch_host_addresses": {
+      "description": "Comma separated list with ip:port formatted remote transport addresses to use.",
+      "example": "quickstart-es-http:9200",
+      "title": "Host Addresses",
+      "type": "string"
+    },
+    "elasticsearch_index_name": {
+      "description": "The name of the index to act against.",
+      "example": "data",
+      "title": "Index in ElasticSearch",
+      "type": "string"
+    },
+    "elasticsearch_password": {
+      "oneOf": [
+        {
+          "description": "Password to connect to ElasticSearch.",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the elasticsearch_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "elasticsearch_user": {
+      "description": "Username to connect to ElasticSearch.",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "elasticsearch_cluster_name",
+    "elasticsearch_host_addresses",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/ftps_sink_0.1.json
+++ b/schemas/ftps_sink_0.1.json
@@ -1,0 +1,168 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "ftps_connection_host": {
+      "description": "Hostname of the FTP server",
+      "title": "Connection Host",
+      "type": "string"
+    },
+    "ftps_connection_port": {
+      "default": 21,
+      "description": "Port of the FTP server",
+      "title": "Connection Port",
+      "type": "string"
+    },
+    "ftps_directory_name": {
+      "description": "The starting directory",
+      "title": "Directory Name",
+      "type": "string"
+    },
+    "ftps_file_exist": {
+      "default": "Override",
+      "description": "How to behave in case of file already existent. There are 4 enums and the value can be one of Override, Append, Fail or Ignore",
+      "title": "File Existence",
+      "type": "string"
+    },
+    "ftps_passive_mode": {
+      "default": false,
+      "description": "Sets passive mode connection",
+      "title": "Passive Mode",
+      "type": "boolean"
+    },
+    "ftps_password": {
+      "oneOf": [
+        {
+          "description": "The password to access the FTP server",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the ftps_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "ftps_username": {
+      "description": "The username to access the FTP server",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "ftps_connection_host",
+    "ftps_connection_port",
+    "ftps_username",
+    "ftps_password",
+    "ftps_directory_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/ftps_source_0.1.json
+++ b/schemas/ftps_source_0.1.json
@@ -1,0 +1,174 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "ftps_connection_host": {
+      "description": "Hostname of the FTPS server",
+      "title": "Connection Host",
+      "type": "string"
+    },
+    "ftps_connection_port": {
+      "default": 21,
+      "description": "Port of the FTPS server",
+      "title": "Connection Port",
+      "type": "string"
+    },
+    "ftps_directory_name": {
+      "description": "The starting directory",
+      "title": "Directory Name",
+      "type": "string"
+    },
+    "ftps_idempotent": {
+      "default": true,
+      "description": "Skip already processed files.",
+      "title": "Idempotency",
+      "type": "boolean"
+    },
+    "ftps_passive_mode": {
+      "default": false,
+      "description": "Sets passive mode connection",
+      "title": "Passive Mode",
+      "type": "boolean"
+    },
+    "ftps_password": {
+      "oneOf": [
+        {
+          "description": "The password to access the FTPS server",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the ftps_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "ftps_recursive": {
+      "default": false,
+      "description": "If a directory, will look for files in all the sub-directories as well.",
+      "title": "Recursive",
+      "type": "boolean"
+    },
+    "ftps_username": {
+      "description": "The username to access the FTPS server",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "ftps_connection_host",
+    "ftps_connection_port",
+    "ftps_username",
+    "ftps_password",
+    "ftps_directory_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/google_bigquery_sink_0.1.json
+++ b/schemas/google_bigquery_sink_0.1.json
@@ -1,0 +1,137 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "gcp_credentials_file_location": {
+      "description": "The credential to access Google Cloud Platform api services",
+      "title": "Google Cloud Platform Credential File",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "gcp_dataset": {
+      "description": "The Big Query Dataset Id",
+      "title": "Big Query Dataset Id",
+      "type": "string"
+    },
+    "gcp_project_id": {
+      "description": "Google Cloud Project id",
+      "title": "Google Cloud Project Id",
+      "type": "string"
+    },
+    "gcp_table": {
+      "description": "The Big Query Table Id",
+      "title": "Big Query Table Id",
+      "type": "string"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "gcp_project_id",
+    "gcp_dataset",
+    "gcp_table",
+    "gcp_credentials_file_location",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/google_functions_sink_0.1.json
+++ b/schemas/google_functions_sink_0.1.json
@@ -1,0 +1,137 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "gcp_function_name": {
+      "description": "The Function Name",
+      "title": "Function Name",
+      "type": "string"
+    },
+    "gcp_project_id": {
+      "description": "The Google Cloud Functions Project Id",
+      "title": "Project Id",
+      "type": "string"
+    },
+    "gcp_region": {
+      "description": "The Region where the Google Cloud Functions has been deployed",
+      "title": "Region",
+      "type": "string"
+    },
+    "gcp_service_account_key": {
+      "description": "The Service account key that can be used as credentials for the Google Cloud Functions platform",
+      "title": "Service Account Key",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "gcp_project_id",
+    "gcp_function_name",
+    "gcp_region",
+    "gcp_service_account_key",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/google_pubsub_sink_0.1.json
+++ b/schemas/google_pubsub_sink_0.1.json
@@ -1,0 +1,132 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "gcp_destination_name": {
+      "description": "The Destination Name",
+      "title": "Destination Name",
+      "type": "string"
+    },
+    "gcp_project_id": {
+      "description": "The Google Cloud PubSub Project Id",
+      "title": "Project Id",
+      "type": "string"
+    },
+    "gcp_service_account_key": {
+      "description": "The Service account key that can be used as credentials for the PubSub publisher/subscriber",
+      "format": "base64",
+      "title": "Service Account Key",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "gcp_project_id",
+    "gcp_destination_name",
+    "gcp_service_account_key",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/google_pubsub_source_0.1.json
+++ b/schemas/google_pubsub_source_0.1.json
@@ -1,0 +1,150 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "gcp_concurrent_consumers": {
+      "default": 1,
+      "description": "The number of parallel streams consuming from the subscription",
+      "title": "Concurrent Consumers",
+      "type": "integer"
+    },
+    "gcp_max_messages_per_poll": {
+      "default": 1,
+      "description": "The max number of messages to receive from the server in a single API call",
+      "title": "Max Messages Per Poll",
+      "type": "integer"
+    },
+    "gcp_project_id": {
+      "description": "The Google Cloud PubSub Project Id",
+      "title": "Project Id",
+      "type": "string"
+    },
+    "gcp_service_account_key": {
+      "description": "The Service account key that can be used as credentials for the PubSub publisher/subscriber",
+      "format": "base64",
+      "title": "Service Account Key",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "gcp_subscription_name": {
+      "description": "The Subscription Name",
+      "title": "Subscription Name",
+      "type": "string"
+    },
+    "gcp_synchronous_pull": {
+      "default": false,
+      "description": "If Synchronously pull batches of messages is enabled or not",
+      "title": "Synchronous Pull",
+      "type": "boolean"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "gcp_project_id",
+    "gcp_subscription_name",
+    "gcp_service_account_key",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/google_storage_sink_0.1.json
+++ b/schemas/google_storage_sink_0.1.json
@@ -1,0 +1,132 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "gcp_auto_create_bucket": {
+      "default": false,
+      "description": "Setting the autocreation of the Google Cloud Storage bucket bucketNameOrArn.",
+      "title": "Autocreate Bucket",
+      "type": "boolean"
+    },
+    "gcp_bucket_name_or_arn": {
+      "description": "The Bucket Name or Bucket ARN",
+      "title": "Bucket Name Or ARN",
+      "type": "string"
+    },
+    "gcp_service_account_key": {
+      "description": "The Service account key that can be used as credentials for the Google Cloud Storage access.",
+      "format": "base64",
+      "title": "Service Account Key",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "gcp_bucket_name_or_arn",
+    "gcp_service_account_key",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/google_storage_source_0.1.json
+++ b/schemas/google_storage_source_0.1.json
@@ -1,0 +1,138 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "gcp_auto_create_bucket": {
+      "default": false,
+      "description": "Setting the autocreation of the Google Cloud Storage bucket bucketNameOrArn.",
+      "title": "Autocreate Bucket",
+      "type": "boolean"
+    },
+    "gcp_bucket_name_or_arn": {
+      "description": "The Bucket Name or Bucket ARN",
+      "title": "Bucket Name Or ARN",
+      "type": "string"
+    },
+    "gcp_delete_after_read": {
+      "default": true,
+      "description": "Delete objects after consuming them",
+      "title": "Auto-delete Objects",
+      "type": "boolean"
+    },
+    "gcp_service_account_key": {
+      "description": "The Service account key that can be used as credentials for the Google Cloud Storage access.",
+      "format": "base64",
+      "title": "Service Account Key",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "gcp_bucket_name_or_arn",
+    "gcp_service_account_key",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/http_sink_0.1.json
+++ b/schemas/http_sink_0.1.json
@@ -1,0 +1,126 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "http_method": {
+      "default": "POST",
+      "description": "The HTTP method to use",
+      "title": "Method",
+      "type": "string"
+    },
+    "http_url": {
+      "description": "The URL to send data to",
+      "example": "https://my-service/path",
+      "pattern": "^(http|https)://.*",
+      "title": "URL",
+      "type": "string"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "http_url",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/jira_source_0.1.json
+++ b/schemas/jira_source_0.1.json
@@ -1,0 +1,150 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "jira_jira_url": {
+      "description": "The URL of your instance of Jira",
+      "example": "http://my_jira.com:8081",
+      "title": "Jira URL",
+      "type": "string"
+    },
+    "jira_jql": {
+      "description": "A query to filter issues",
+      "example": "project=MyProject",
+      "title": "JQL",
+      "type": "string"
+    },
+    "jira_password": {
+      "oneOf": [
+        {
+          "description": "The password to access Jira",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the jira_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "jira_username": {
+      "description": "The username to access Jira",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "jira_jira_url",
+    "jira_username",
+    "jira_password",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/jms_amqp_10_sink_0.1.json
+++ b/schemas/jms_amqp_10_sink_0.1.json
@@ -1,0 +1,131 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "jms_amqp_destination_name": {
+      "description": "The JMS destination name",
+      "title": "Destination Name",
+      "type": "string"
+    },
+    "jms_amqp_destination_type": {
+      "default": "queue",
+      "description": "The JMS destination type (i.e.: queue or topic)",
+      "title": "Destination Type",
+      "type": "string"
+    },
+    "jms_amqp_remote_u_r_i": {
+      "description": "The JMS URL",
+      "example": "amqp://my-host:31616",
+      "title": "Broker URL",
+      "type": "string"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "jms_amqp_destination_name",
+    "jms_amqp_remote_u_r_i",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/jms_amqp_10_source_0.1.json
+++ b/schemas/jms_amqp_10_source_0.1.json
@@ -1,0 +1,131 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "jms_amqp_destination_name": {
+      "description": "The JMS destination name",
+      "title": "Destination Name",
+      "type": "string"
+    },
+    "jms_amqp_destination_type": {
+      "default": "queue",
+      "description": "The JMS destination type (i.e.: queue or topic)",
+      "title": "Destination Type",
+      "type": "string"
+    },
+    "jms_amqp_remote_u_r_i": {
+      "description": "The JMS URL",
+      "example": "amqp://my-host:31616",
+      "title": "Broker URL",
+      "type": "string"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "jms_amqp_destination_name",
+    "jms_amqp_remote_u_r_i",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/jms_apache_artemis_sink_0.1.json
+++ b/schemas/jms_apache_artemis_sink_0.1.json
@@ -1,0 +1,132 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "jms_artemis_broker_u_r_l": {
+      "description": "The JMS URL",
+      "example": "tcp://my-host:61616",
+      "title": "Broker URL",
+      "type": "string"
+    },
+    "jms_artemis_destination_name": {
+      "description": "The JMS destination name",
+      "example": "person",
+      "title": "Destination Name",
+      "type": "string"
+    },
+    "jms_artemis_destination_type": {
+      "default": "queue",
+      "description": "The JMS destination type (i.e.: queue or topic)",
+      "title": "Destination Type",
+      "type": "string"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "jms_artemis_destination_name",
+    "jms_artemis_broker_u_r_l",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/jms_apache_artemis_source_0.1.json
+++ b/schemas/jms_apache_artemis_source_0.1.json
@@ -1,0 +1,131 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "jms_artemis_broker_u_r_l": {
+      "description": "The JMS URL",
+      "example": "tcp://k3s-node-master.usersys.redhat.com:31616",
+      "title": "Broker URL",
+      "type": "string"
+    },
+    "jms_artemis_destination_name": {
+      "description": "The JMS destination name",
+      "title": "Destination Name",
+      "type": "string"
+    },
+    "jms_artemis_destination_type": {
+      "default": "queue",
+      "description": "The JMS destination type (i.e.: queue or topic)",
+      "title": "Destination Type",
+      "type": "string"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "jms_artemis_destination_name",
+    "jms_artemis_broker_u_r_l",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/mariadb_sink_0.1.json
+++ b/schemas/mariadb_sink_0.1.json
@@ -1,0 +1,163 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "db_database_name": {
+      "description": "The Database Name we are pointing",
+      "title": "Database Name",
+      "type": "string"
+    },
+    "db_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured MariaDB Database",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the db_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "db_query": {
+      "description": "The Query to execute against the MariaDB Database",
+      "example": "INSERT INTO accounts (username,city) VALUES (:#username,:#city)",
+      "title": "Query",
+      "type": "string"
+    },
+    "db_server_name": {
+      "description": "Server Name for the data source",
+      "example": "localhost",
+      "title": "Server Name",
+      "type": "string"
+    },
+    "db_server_port": {
+      "default": 3306,
+      "description": "Server Port for the data source",
+      "title": "Server Port",
+      "type": "string"
+    },
+    "db_username": {
+      "description": "The username to use for accessing a secured MariaDB Database",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "db_server_name",
+    "db_username",
+    "db_password",
+    "db_query",
+    "db_database_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/mariadb_source_0.1.json
+++ b/schemas/mariadb_source_0.1.json
@@ -1,0 +1,169 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "db_consumed_query": {
+      "description": "A query to run on a tuple consumed",
+      "example": "DELETE FROM accounts where user_id = :#user_id",
+      "title": "Consumed Query",
+      "type": "string"
+    },
+    "db_database_name": {
+      "description": "The Database Name we are pointing",
+      "title": "Database Name",
+      "type": "string"
+    },
+    "db_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured MariaDB Database",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the db_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "db_query": {
+      "description": "The Query to execute against the MariaDB Database",
+      "example": "INSERT INTO accounts (username,city) VALUES (:#username,:#city)",
+      "title": "Query",
+      "type": "string"
+    },
+    "db_server_name": {
+      "description": "Server Name for the data source",
+      "example": "localhost",
+      "title": "Server Name",
+      "type": "string"
+    },
+    "db_server_port": {
+      "default": 3306,
+      "description": "Server Port for the data source",
+      "title": "Server Port",
+      "type": "string"
+    },
+    "db_username": {
+      "description": "The username to use for accessing a secured MariaDB Database",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "db_server_name",
+    "db_username",
+    "db_password",
+    "db_query",
+    "db_database_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/minio_sink_0.1.json
+++ b/schemas/minio_sink_0.1.json
@@ -1,0 +1,167 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "minio_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from Minio",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the minio_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "minio_auto_create_bucket": {
+      "default": false,
+      "description": "Setting the autocreation of the Minio bucket bucketName.",
+      "title": "Autocreate Bucket",
+      "type": "boolean"
+    },
+    "minio_bucket_name": {
+      "description": "The Minio Bucket name",
+      "title": "Bucket Name",
+      "type": "string"
+    },
+    "minio_endpoint": {
+      "description": "The Minio Endpoint, it can be an URL, domain name, IPv4 address or IPv6 address.",
+      "example": "http://localhost:9000",
+      "title": "Endpoint",
+      "type": "string"
+    },
+    "minio_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from Minio",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the minio_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "processors": {}
+  },
+  "required": [
+    "minio_bucket_name",
+    "minio_access_key",
+    "minio_secret_key",
+    "minio_endpoint",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/minio_source_0.1.json
+++ b/schemas/minio_source_0.1.json
@@ -1,0 +1,173 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "minio_access_key": {
+      "oneOf": [
+        {
+          "description": "The access key obtained from Minio",
+          "format": "password",
+          "title": "Access Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the minio_access_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Access Key",
+      "x-group": "credentials"
+    },
+    "minio_auto_create_bucket": {
+      "default": false,
+      "description": "Setting the autocreation of the Minio bucket bucketName.",
+      "title": "Autocreate Bucket",
+      "type": "boolean"
+    },
+    "minio_bucket_name": {
+      "description": "The Minio Bucket name",
+      "title": "Bucket Name",
+      "type": "string"
+    },
+    "minio_delete_after_read": {
+      "default": true,
+      "description": "Delete objects after consuming them",
+      "title": "Auto-delete Objects",
+      "type": "boolean"
+    },
+    "minio_endpoint": {
+      "description": "The Minio Endpoint, it can be an URL, domain name, IPv4 address or IPv6 address.",
+      "example": "http://localhost:9000",
+      "title": "Endpoint",
+      "type": "string"
+    },
+    "minio_secret_key": {
+      "oneOf": [
+        {
+          "description": "The secret key obtained from Minio",
+          "format": "password",
+          "title": "Secret Key",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the minio_secret_key",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Secret Key",
+      "x-group": "credentials"
+    },
+    "processors": {}
+  },
+  "required": [
+    "minio_bucket_name",
+    "minio_access_key",
+    "minio_secret_key",
+    "minio_endpoint",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/mongodb_sink_0.1.json
+++ b/schemas/mongodb_sink_0.1.json
@@ -1,0 +1,164 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "mongodb_collection": {
+      "description": "Sets the name of the MongoDB collection to bind to this endpoint.",
+      "title": "MongoDB Collection",
+      "type": "string"
+    },
+    "mongodb_create_collection": {
+      "default": false,
+      "description": "Create collection during initialisation if it doesn't exist.",
+      "title": "Collection",
+      "type": "boolean"
+    },
+    "mongodb_database": {
+      "description": "Sets the name of the MongoDB database to target.",
+      "title": "MongoDB Database",
+      "type": "string"
+    },
+    "mongodb_hosts": {
+      "description": "Comma separated list of MongoDB Host Addresses in host:port format.",
+      "title": "MongoDB Hosts",
+      "type": "string"
+    },
+    "mongodb_password": {
+      "oneOf": [
+        {
+          "description": "User password for accessing MongoDB.",
+          "format": "password",
+          "title": "MongoDB Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the mongodb_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "MongoDB Password",
+      "x-group": "credentials"
+    },
+    "mongodb_username": {
+      "description": "Username for accessing MongoDB.",
+      "title": "MongoDB Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "mongodb_write_concern": {
+      "description": "Configure the level of acknowledgment requested from MongoDB for write operations, possible values are ACKNOWLEDGED, W1, W2, W3, UNACKNOWLEDGED, JOURNALED, MAJORITY.",
+      "title": "Write Concern",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "mongodb_hosts",
+    "mongodb_collection",
+    "mongodb_database",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/mongodb_source_0.1.json
+++ b/schemas/mongodb_source_0.1.json
@@ -1,0 +1,164 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "mongodb_collection": {
+      "description": "Sets the name of the MongoDB collection to bind to this endpoint.",
+      "title": "MongoDB Collection",
+      "type": "string"
+    },
+    "mongodb_database": {
+      "description": "Sets the name of the MongoDB database to target.",
+      "title": "MongoDB Database",
+      "type": "string"
+    },
+    "mongodb_hosts": {
+      "description": "Comma separated list of MongoDB Host Addresses in host:port format.",
+      "title": "MongoDB Hosts",
+      "type": "string"
+    },
+    "mongodb_password": {
+      "oneOf": [
+        {
+          "description": "User password for accessing MongoDB.",
+          "format": "password",
+          "title": "MongoDB Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the mongodb_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "MongoDB Password",
+      "x-group": "credentials"
+    },
+    "mongodb_persistent_tail_tracking": {
+      "default": false,
+      "description": "Enable persistent tail tracking, which is a mechanism to keep track of the last consumed message across system restarts. The next time the system is up, the endpoint will recover the cursor from the point where it last stopped slurping records.",
+      "title": "MongoDB Persistent Tail Tracking",
+      "type": "boolean"
+    },
+    "mongodb_tail_track_increasing_field": {
+      "description": "Correlation field in the incoming record which is of increasing nature and will be used to position the tailing cursor every time it is generated.",
+      "title": "MongoDB Tail Track Increasing Field",
+      "type": "string"
+    },
+    "mongodb_username": {
+      "description": "Username for accessing MongoDB. The username must be present in the MongoDB's authentication database (authenticationDatabase). By default, the MongoDB authenticationDatabase is 'admin'.",
+      "title": "MongoDB Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "processors": {}
+  },
+  "required": [
+    "mongodb_hosts",
+    "mongodb_collection",
+    "mongodb_database",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/mysql_sink_0.1.json
+++ b/schemas/mysql_sink_0.1.json
@@ -1,0 +1,163 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "db_database_name": {
+      "description": "The Database Name we are pointing",
+      "title": "Database Name",
+      "type": "string"
+    },
+    "db_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured MySQL Database",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the db_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "db_query": {
+      "description": "The Query to execute against the MySQL Database",
+      "example": "INSERT INTO accounts (username,city) VALUES (:#username,:#city)",
+      "title": "Query",
+      "type": "string"
+    },
+    "db_server_name": {
+      "description": "Server Name for the data source",
+      "example": "localhost",
+      "title": "Server Name",
+      "type": "string"
+    },
+    "db_server_port": {
+      "default": 3306,
+      "description": "Server Port for the data source",
+      "title": "Server Port",
+      "type": "string"
+    },
+    "db_username": {
+      "description": "The username to use for accessing a secured MySQL Database",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "db_server_name",
+    "db_username",
+    "db_password",
+    "db_query",
+    "db_database_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/mysql_source_0.1.json
+++ b/schemas/mysql_source_0.1.json
@@ -1,0 +1,169 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "db_consumed_query": {
+      "description": "A query to run on a tuple consumed",
+      "example": "DELETE FROM accounts where user_id = :#user_id",
+      "title": "Consumed Query",
+      "type": "string"
+    },
+    "db_database_name": {
+      "description": "The Database Name we are pointing",
+      "title": "Database Name",
+      "type": "string"
+    },
+    "db_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured MySQL Database",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the db_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "db_query": {
+      "description": "The Query to execute against the MySQL Database",
+      "example": "INSERT INTO accounts (username,city) VALUES (:#username,:#city)",
+      "title": "Query",
+      "type": "string"
+    },
+    "db_server_name": {
+      "description": "Server Name for the data source",
+      "example": "localhost",
+      "title": "Server Name",
+      "type": "string"
+    },
+    "db_server_port": {
+      "default": 3306,
+      "description": "Server Port for the data source",
+      "title": "Server Port",
+      "type": "string"
+    },
+    "db_username": {
+      "description": "The username to use for accessing a secured MySQL Database",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "db_server_name",
+    "db_username",
+    "db_password",
+    "db_query",
+    "db_database_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/postgresql_sink_0.1.json
+++ b/schemas/postgresql_sink_0.1.json
@@ -1,0 +1,163 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "db_database_name": {
+      "description": "The Database Name we are pointing",
+      "title": "Database Name",
+      "type": "string"
+    },
+    "db_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured PostgreSQL Database",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the db_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "db_query": {
+      "description": "The Query to execute against the PostgreSQL Database",
+      "example": "INSERT INTO accounts (username,city) VALUES (:#username,:#city)",
+      "title": "Query",
+      "type": "string"
+    },
+    "db_server_name": {
+      "description": "Server Name for the data source",
+      "example": "localhost",
+      "title": "Server Name",
+      "type": "string"
+    },
+    "db_server_port": {
+      "default": 5432,
+      "description": "Server Port for the data source",
+      "title": "Server Port",
+      "type": "string"
+    },
+    "db_username": {
+      "description": "The username to use for accessing a secured PostgreSQL Database",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "db_server_name",
+    "db_username",
+    "db_password",
+    "db_query",
+    "db_database_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/postgresql_source_0.1.json
+++ b/schemas/postgresql_source_0.1.json
@@ -1,0 +1,169 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "db_consumed_query": {
+      "description": "A query to run on a tuple consumed",
+      "example": "DELETE FROM accounts where user_id = :#user_id",
+      "title": "Consumed Query",
+      "type": "string"
+    },
+    "db_database_name": {
+      "description": "The Database Name we are pointing",
+      "title": "Database Name",
+      "type": "string"
+    },
+    "db_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured PostgreSQL Database",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the db_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "db_query": {
+      "description": "The Query to execute against the PostgreSQL Database",
+      "example": "INSERT INTO accounts (username,city) VALUES (:#username,:#city)",
+      "title": "Query",
+      "type": "string"
+    },
+    "db_server_name": {
+      "description": "Server Name for the data source",
+      "example": "localhost",
+      "title": "Server Name",
+      "type": "string"
+    },
+    "db_server_port": {
+      "default": 5432,
+      "description": "Server Port for the data source",
+      "title": "Server Port",
+      "type": "string"
+    },
+    "db_username": {
+      "description": "The username to use for accessing a secured PostgreSQL Database",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "db_server_name",
+    "db_username",
+    "db_password",
+    "db_query",
+    "db_database_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/rest_openapi_sink_0.1.json
+++ b/schemas/rest_openapi_sink_0.1.json
@@ -1,0 +1,126 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "rest_openapi_operation": {
+      "description": "The operation to call",
+      "title": "Operation ID",
+      "type": "string"
+    },
+    "rest_openapi_specification": {
+      "description": "URI to the OpenApi specification file",
+      "example": "https://api.example.com/openapi.json",
+      "pattern": "^(http|https|file|classpath)://.*",
+      "title": "Specification URI",
+      "type": "string"
+    }
+  },
+  "required": [
+    "rest_openapi_specification",
+    "rest_openapi_operation",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/salesforce_create_sink_0.1.json
+++ b/schemas/salesforce_create_sink_0.1.json
@@ -1,0 +1,174 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "salesforce_client_id": {
+      "description": "The Salesforce application consumer key",
+      "title": "Consumer Key",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "salesforce_client_secret": {
+      "oneOf": [
+        {
+          "description": "The Salesforce application consumer secret",
+          "format": "password",
+          "title": "Consumer Secret",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the salesforce_client_secret",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Consumer Secret",
+      "x-group": "credentials"
+    },
+    "salesforce_login_url": {
+      "default": "https://login.salesforce.com",
+      "description": "The Salesforce instance login URL",
+      "title": "Login URL",
+      "type": "string"
+    },
+    "salesforce_password": {
+      "oneOf": [
+        {
+          "description": "The Salesforce user password",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the salesforce_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "salesforce_s_object_name": {
+      "description": "Type of the object",
+      "example": "Contact",
+      "title": "Object Name",
+      "type": "string"
+    },
+    "salesforce_user_name": {
+      "description": "The Salesforce username",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    }
+  },
+  "required": [
+    "salesforce_client_id",
+    "salesforce_client_secret",
+    "salesforce_user_name",
+    "salesforce_password",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/salesforce_delete_sink_0.1.json
+++ b/schemas/salesforce_delete_sink_0.1.json
@@ -1,0 +1,168 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "salesforce_client_id": {
+      "description": "The Salesforce application consumer key",
+      "title": "Consumer Key",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "salesforce_client_secret": {
+      "oneOf": [
+        {
+          "description": "The Salesforce application consumer secret",
+          "format": "password",
+          "title": "Consumer Secret",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the salesforce_client_secret",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Consumer Secret",
+      "x-group": "credentials"
+    },
+    "salesforce_login_url": {
+      "default": "https://login.salesforce.com",
+      "description": "The Salesforce instance login URL",
+      "title": "Login URL",
+      "type": "string"
+    },
+    "salesforce_password": {
+      "oneOf": [
+        {
+          "description": "The Salesforce user password",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the salesforce_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "salesforce_user_name": {
+      "description": "The Salesforce username",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    }
+  },
+  "required": [
+    "salesforce_client_id",
+    "salesforce_client_secret",
+    "salesforce_user_name",
+    "salesforce_password",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/salesforce_streaming_source_0.1.json
+++ b/schemas/salesforce_streaming_source_0.1.json
@@ -1,0 +1,174 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "salesforce_client_id": {
+      "description": "The Salesforce application consumer key",
+      "title": "Consumer Key",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "salesforce_client_secret": {
+      "oneOf": [
+        {
+          "description": "The Salesforce application consumer secret",
+          "format": "password",
+          "title": "Consumer Secret",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the salesforce_client_secret",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Consumer Secret",
+      "x-group": "credentials"
+    },
+    "salesforce_login_url": {
+      "default": "https://login.salesforce.com",
+      "description": "The Salesforce instance login URL",
+      "title": "Login URL",
+      "type": "string"
+    },
+    "salesforce_object_name": {
+      "description": "The sObjectName",
+      "title": "objectName",
+      "type": "string"
+    },
+    "salesforce_password": {
+      "oneOf": [
+        {
+          "description": "The Salesforce user password",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the salesforce_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "salesforce_user_name": {
+      "description": "The Salesforce username",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    }
+  },
+  "required": [
+    "salesforce_object_name",
+    "salesforce_client_id",
+    "salesforce_client_secret",
+    "salesforce_user_name",
+    "salesforce_password",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/salesforce_update_sink_0.1.json
+++ b/schemas/salesforce_update_sink_0.1.json
@@ -1,0 +1,181 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "salesforce_client_id": {
+      "description": "The Salesforce application consumer key",
+      "title": "Consumer Key",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "salesforce_client_secret": {
+      "oneOf": [
+        {
+          "description": "The Salesforce application consumer secret",
+          "format": "password",
+          "title": "Consumer Secret",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the salesforce_client_secret",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Consumer Secret",
+      "x-group": "credentials"
+    },
+    "salesforce_login_url": {
+      "default": "https://login.salesforce.com",
+      "description": "The Salesforce instance login URL",
+      "title": "Login URL",
+      "type": "string"
+    },
+    "salesforce_password": {
+      "oneOf": [
+        {
+          "description": "The Salesforce user password",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the salesforce_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "salesforce_s_object_id": {
+      "description": "Id of the object. Only required if using key-value pair.",
+      "title": "Object Id",
+      "type": "string"
+    },
+    "salesforce_s_object_name": {
+      "description": "Type of the object. Only required if using key-value pair.",
+      "example": "Contact",
+      "title": "Object Name",
+      "type": "string"
+    },
+    "salesforce_user_name": {
+      "description": "The Salesforce username",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    }
+  },
+  "required": [
+    "salesforce_s_object_name",
+    "salesforce_s_object_id",
+    "salesforce_client_id",
+    "salesforce_client_secret",
+    "salesforce_user_name",
+    "salesforce_password",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/sftp_sink_0.1.json
+++ b/schemas/sftp_sink_0.1.json
@@ -1,0 +1,168 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "sftp_connection_host": {
+      "description": "Hostname of the FTP server",
+      "title": "Connection Host",
+      "type": "string"
+    },
+    "sftp_connection_port": {
+      "default": 22,
+      "description": "Port of the FTP server",
+      "title": "Connection Port",
+      "type": "string"
+    },
+    "sftp_directory_name": {
+      "description": "The starting directory",
+      "title": "Directory Name",
+      "type": "string"
+    },
+    "sftp_file_exist": {
+      "default": "Override",
+      "description": "How to behave in case of file already existent. There are 4 enums and the value can be one of Override, Append, Fail or Ignore",
+      "title": "File Existence",
+      "type": "string"
+    },
+    "sftp_passive_mode": {
+      "default": false,
+      "description": "Sets passive mode connection",
+      "title": "Passive Mode",
+      "type": "boolean"
+    },
+    "sftp_password": {
+      "oneOf": [
+        {
+          "description": "The password to access the FTP server",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the sftp_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "sftp_username": {
+      "description": "The username to access the FTP server",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    }
+  },
+  "required": [
+    "sftp_connection_host",
+    "sftp_connection_port",
+    "sftp_username",
+    "sftp_password",
+    "sftp_directory_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/sftp_source_0.1.json
+++ b/schemas/sftp_source_0.1.json
@@ -1,0 +1,174 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "sftp_connection_host": {
+      "description": "Hostname of the SFTP server",
+      "title": "Connection Host",
+      "type": "string"
+    },
+    "sftp_connection_port": {
+      "default": 22,
+      "description": "Port of the FTP server",
+      "title": "Connection Port",
+      "type": "string"
+    },
+    "sftp_directory_name": {
+      "description": "The starting directory",
+      "title": "Directory Name",
+      "type": "string"
+    },
+    "sftp_idempotent": {
+      "default": true,
+      "description": "Skip already processed files.",
+      "title": "Idempotency",
+      "type": "boolean"
+    },
+    "sftp_passive_mode": {
+      "default": false,
+      "description": "Sets passive mode connection",
+      "title": "Passive Mode",
+      "type": "boolean"
+    },
+    "sftp_password": {
+      "oneOf": [
+        {
+          "description": "The password to access the SFTP server",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the sftp_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "sftp_recursive": {
+      "default": false,
+      "description": "If a directory, will look for files in all the sub-directories as well.",
+      "title": "Recursive",
+      "type": "boolean"
+    },
+    "sftp_username": {
+      "description": "The username to access the SFTP server",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    }
+  },
+  "required": [
+    "sftp_connection_host",
+    "sftp_connection_port",
+    "sftp_username",
+    "sftp_password",
+    "sftp_directory_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/slack_sink_0.1.json
+++ b/schemas/slack_sink_0.1.json
@@ -1,0 +1,152 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "slack_channel": {
+      "description": "The Slack channel to send messages to.",
+      "example": "#myroom",
+      "title": "Channel",
+      "type": "string"
+    },
+    "slack_icon_emoji": {
+      "description": "Use a Slack emoji as an avatar.",
+      "title": "Icon Emoji",
+      "type": "string"
+    },
+    "slack_icon_url": {
+      "description": "The avatar that the component will use when sending message to a channel or user.",
+      "title": "Icon URL",
+      "type": "string"
+    },
+    "slack_username": {
+      "description": "This is the username that the bot will have when sending messages to a channel or user.",
+      "title": "Username",
+      "type": "string"
+    },
+    "slack_webhook_url": {
+      "oneOf": [
+        {
+          "description": "The webhook URL used by the Slack channel to handle incoming messages.",
+          "format": "password",
+          "title": "Webhook URL",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the slack_webhook_url",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Webhook URL",
+      "x-group": "credentials"
+    }
+  },
+  "required": [
+    "slack_channel",
+    "slack_webhook_url",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/slack_source_0.1.json
+++ b/schemas/slack_source_0.1.json
@@ -1,0 +1,143 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "slack_channel": {
+      "description": "The Slack channel to receive messages from",
+      "example": "#myroom",
+      "title": "Channel",
+      "type": "string"
+    },
+    "slack_delay": {
+      "description": "The delay between polls",
+      "example": "1s",
+      "title": "Delay",
+      "type": "string"
+    },
+    "slack_token": {
+      "oneOf": [
+        {
+          "description": "The token to access Slack. A Slack app is needed. This app needs to have channels:history and channels:read permissions. The Bot User OAuth Access Token is the kind of token needed.",
+          "format": "password",
+          "title": "Token",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the slack_token",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Token",
+      "x-group": "credentials"
+    }
+  },
+  "required": [
+    "slack_channel",
+    "slack_token",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/sqlserver_sink_0.1.json
+++ b/schemas/sqlserver_sink_0.1.json
@@ -1,0 +1,163 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "db_database_name": {
+      "description": "The Database Name we are pointing",
+      "title": "Database Name",
+      "type": "string"
+    },
+    "db_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured SQL Server Database",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the db_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "db_query": {
+      "description": "The Query to execute against the SQL Server Database",
+      "example": "INSERT INTO accounts (username,city) VALUES (:#username,:#city)",
+      "title": "Query",
+      "type": "string"
+    },
+    "db_server_name": {
+      "description": "Server Name for the data source",
+      "example": "localhost",
+      "title": "Server Name",
+      "type": "string"
+    },
+    "db_server_port": {
+      "default": 1433,
+      "description": "Server Port for the data source",
+      "title": "Server Port",
+      "type": "string"
+    },
+    "db_username": {
+      "description": "The username to use for accessing a secured SQL Server Database",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "db_server_name",
+    "db_username",
+    "db_password",
+    "db_query",
+    "db_database_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/sqlserver_source_0.1.json
+++ b/schemas/sqlserver_source_0.1.json
@@ -1,0 +1,169 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "db_consumed_query": {
+      "description": "A query to run on a tuple consumed",
+      "example": "DELETE FROM accounts where user_id = :#user_id",
+      "title": "Consumed Query",
+      "type": "string"
+    },
+    "db_database_name": {
+      "description": "The Database Name we are pointing",
+      "title": "Database Name",
+      "type": "string"
+    },
+    "db_password": {
+      "oneOf": [
+        {
+          "description": "The password to use for accessing a secured SQL Server Database",
+          "format": "password",
+          "title": "Password",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the db_password",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Password",
+      "x-group": "credentials"
+    },
+    "db_query": {
+      "description": "The Query to execute against the SQL Server Database",
+      "example": "INSERT INTO accounts (username,city) VALUES (:#username,:#city)",
+      "title": "Query",
+      "type": "string"
+    },
+    "db_server_name": {
+      "description": "Server Name for the data source",
+      "example": "localhost",
+      "title": "Server Name",
+      "type": "string"
+    },
+    "db_server_port": {
+      "default": 1433,
+      "description": "Server Port for the data source",
+      "title": "Server Port",
+      "type": "string"
+    },
+    "db_username": {
+      "description": "The username to use for accessing a secured SQL Server Database",
+      "title": "Username",
+      "type": "string",
+      "x-group": "credentials"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {}
+  },
+  "required": [
+    "db_server_name",
+    "db_username",
+    "db_password",
+    "db_query",
+    "db_database_name",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/telegram_sink_0.1.json
+++ b/schemas/telegram_sink_0.1.json
@@ -1,0 +1,135 @@
+{
+  "$defs": {
+    "data_shape": {
+      "consumes": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/octet-stream",
+            "enum": [
+              "application/octet-stream"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "consumes": {
+          "$ref": "#/$defs/data_shape/consumes"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "telegram_authorization_token": {
+      "oneOf": [
+        {
+          "description": "The token to access your bot on Telegram. You you can obtain it from the Telegram @botfather.",
+          "format": "password",
+          "title": "Token",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the telegram_authorization_token",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Token",
+      "x-group": "credentials"
+    },
+    "telegram_chat_id": {
+      "description": "The Chat ID where messages should be sent by default",
+      "title": "Chat ID",
+      "type": "string"
+    }
+  },
+  "required": [
+    "telegram_authorization_token",
+    "kafka_topic"
+  ],
+  "type": "object"
+}

--- a/schemas/telegram_source_0.1.json
+++ b/schemas/telegram_source_0.1.json
@@ -1,0 +1,130 @@
+{
+  "$defs": {
+    "data_shape": {
+      "produces": {
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "default": "application/json",
+            "enum": [
+              "application/json"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "type": "object"
+      }
+    },
+    "error_handler": {
+      "dead_letter_queue": {
+        "additionalProperties": false,
+        "properties": {
+          "topic": {
+            "description": "The name of the Kafka topic used as dead letter queue",
+            "title": "Dead Letter Topic Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "log": {
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "stop": {
+        "additionalProperties": false,
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "data_shape": {
+      "additionalProperties": false,
+      "properties": {
+        "produces": {
+          "$ref": "#/$defs/data_shape/produces"
+        }
+      },
+      "type": "object"
+    },
+    "error_handler": {
+      "default": {
+        "stop": {}
+      },
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "log": {
+              "$ref": "#/$defs/error_handler/log"
+            }
+          },
+          "required": [
+            "log"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "stop": {
+              "$ref": "#/$defs/error_handler/stop"
+            }
+          },
+          "required": [
+            "stop"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "dead_letter_queue": {
+              "$ref": "#/$defs/error_handler/dead_letter_queue"
+            }
+          },
+          "required": [
+            "dead_letter_queue"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "kafka_topic": {
+      "description": "Comma separated list of Kafka topic names",
+      "title": "Topic Names",
+      "type": "string"
+    },
+    "processors": {},
+    "telegram_authorization_token": {
+      "oneOf": [
+        {
+          "description": "The token to access your bot on Telegram. You you can obtain it from the Telegram @botfather.",
+          "format": "password",
+          "title": "Token",
+          "type": "string"
+        },
+        {
+          "description": "An opaque reference to the telegram_authorization_token",
+          "properties": {},
+          "type": "object"
+        }
+      ],
+      "title": "Token",
+      "x-group": "credentials"
+    }
+  },
+  "required": [
+    "telegram_authorization_token",
+    "kafka_topic"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
Adding plain schemas from RHOAS services in order to reuse them for testing purposes. 