### PR TITLE
fix: added schema options to override callback

### DIFF
--- a/pkg/surveyjson/survey.go
+++ b/pkg/surveyjson/survey.go
@@ -37,7 +37,7 @@ type JSONSchemaOptions struct {
 	In                  terminal.FileReader
 	Out                 terminal.FileWriter
 	OutErr              io.Writer
-	Overrides           map[string]func(ctx SchemaContext) error
+	Overrides           map[string]func(o *JSONSchemaOptions, ctx SchemaContext) error
 }
 
 type SchemaContext struct {
@@ -95,7 +95,7 @@ func (o *JSONSchemaOptions) GenerateValues(schemaBytes []byte, existingValues ma
 func (o *JSONSchemaOptions) Recurse(ctx SchemaContext) error {
 
 	if f, ok := o.Overrides[ctx.Name]; ok {
-		return f(ctx)
+		return f(o, ctx)
 	}
 
 	ctx.Required = util.Contains(ctx.RequiredFields, ctx.Name)


### PR DESCRIPTION
When overwriting we now pass the schema options into the override functions as they can then have access to library-defined functions for evaluating the json schema. For example they can now call RecurseObject from the override function and this allows for them to take over some parts but still keep the functionality they may want from the library without redifining.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
