### PR TITLE
feat: now insert empty object when no values needed

### DIFF
--- a/pkg/surveyjson/survey.go
+++ b/pkg/surveyjson/survey.go
@@ -283,10 +283,13 @@ func (o *JSONSchemaOptions) RecurseObject(ctx SchemaContext) error {
 					valid = false
 				}
 			}
-			if valid && len(result.Keys()) > 0 {
+			if valid {
 				ctx.Output.Set(ctx.Name, result)
 			}
 		}
+	} else {
+		// if there are no properties then just insert an empty body.. "name": {}
+		ctx.Output.Set(ctx.Name, make(map[string]*JSONSchemaType))
 	}
 
 	return nil


### PR DESCRIPTION
```
"error_handler": {
  "additionalProperties": false,
  "properties": {
      "log": {
          "additionalProperties": false,
          "type": "object"
        }
  },
  "type": "object"
  }
}
```

Before the following would generate:
```
"error_handler": {}
```

But now generates:
```
"error_handler": {
 "log": {}
}
```
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [ ] Other (please specify)
